### PR TITLE
removing ev-ca! sorry to the people using it try using ev-us2.

### DIFF
--- a/v2/public-resolvers.md
+++ b/v2/public-resolvers.md
@@ -352,14 +352,6 @@ Maintained by Frank Denis.
 sdns://AgcAAAAAAAAAACAd2FCKjFZZBDl8eGRR4I9XYTzzyKcj9vN5_Uw4WLbznw1kb2guY3J5cHRvLnN4Ci9kbnMtcXVlcnk
 
 
-## ev-ca
-Non-logging, uncensored DNS resolver provided by evilvibes.com
-Hosted by: digitalocean.com - Location: Toronto, Canada
-https://www.evilvibes.com/dnscrypt
-
-sdns://AQcAAAAAAAAADjE1OS44OS4xMjQuMTg2IEQWrEIaFrsbJbCmEKctUm-5RDGPmR_stXBjOmIdvRCUHTIuZG5zY3J5cHQtY2VydC5ldmlsdmliZXMuY29t
-
-
 ## ev-us
 Non-logging, uncensored DNS resolver provided by evilvibes.com
 Hosted by: vultr.com - Location: Seattle, USA


### PR DESCRIPTION
I'm removing ev-ca as I don't want to be dealing with both digitalocean and vultr. I'm going to keep everything under vultr as I don't much like digitalocean.