### PR TITLE
Add gridns-sg

### DIFF
--- a/v2/public-resolvers.md
+++ b/v2/public-resolvers.md
@@ -408,6 +408,13 @@ Google DNS (anycast)
 
 sdns://AgUAAAAAAAAAACAe9iTP_15r07rd8_3b_epWVGfjdymdx-5mdRZvMAzBuQ5kbnMuZ29vZ2xlLmNvbQ0vZXhwZXJpbWVudGFs
 
+## gridns-sg
+
+Gridth's public filtering non-logging DNS-over-HTTPS server. Block ads and tracking.
+Hosted in Digital Ocean droplet in SGP region. Upstream to 1.1.1.1.
+
+sdns://AgYAAAAAAAAADDE2Ny45OS4zMS42OSA-GhoPbFPz6XpJLVcIS1uYBwWe4FerFQWHb9g_2j24OBFzZy5kbnMuZ3JpZC5pbi50aAovZG5zLXF1ZXJ5
+
 ## ibksturm
 
 dnscrypt-server (dnscrypt-wrapper - dnsmasq backend), DNSSEC / Non-Logged / Uncensored, OpenNIC


### PR DESCRIPTION
This is my public DoH server with ads and tracking domain filtering, using [mostly the same block list as Pi-Hole](https://github.com/sirn/gridns-deploy/blob/1418380f8f0a628490f9518fefb74a73194b4ab2/ansible/roles/unbound/files/blocklist/blocklist.txt), although the stack is FreeBSD + unbound. The deployment script (Ansible+Terraform) is published at [sirn/gridns-deploy](https://github.com/sirn/gridns-deploy/) for anyone to audit. I think it will be a useful addition for those of us in South East Asia.

I've been testing for a bit over a week and it seems to work without problems so far.