### PR TITLE
Copyfault @ doh-ibksturm

### DIFF
--- a/v2/public-resolvers.md
+++ b/v2/public-resolvers.md
@@ -428,7 +428,7 @@ sdns://AQcAAAAAAAAADzIxNy4xNjIuMjA2LjE3OCB2x0U7IXv1uDMjPD3ypxKY4xhAxu7bxJrlMs0vf
 doh-server (nginx - doh-httpproxy - unbound backend), DNSSEC / Non-Logged / Uncensored, OpenNIC and Root DNS-Zone Copy
 Hosted in Switzerland on a Banana Pi M64 by ibksturm, aka Andreas Ziegler
 
-sdns://AgcAAAAAAAAADzIxNy4xNjIuMjA2LjE3OAAYaWJrc3R1cm0uc3lub2xvZ3kubWU6ODUzCi9kbnMtcXVlcnkk
+sdns://AgcAAAAAAAAADzIxNy4xNjIuMjA2LjE3OAAYaWJrc3R1cm0uc3lub2xvZ3kubWU6ODUzCi9kbnMtcXVlcnk
 
 ## ipredator
 


### PR DESCRIPTION
last night, i did a ctrl-c fault when i added my new doh server (doh-ibksturm) in the sdns:// section

now it should run, sorry at all