### PR TITLE
Add a DoH server from SecureDNS

### DIFF
--- a/v2/public-resolvers.md
+++ b/v2/public-resolvers.md
@@ -645,6 +645,12 @@ Uncensored and no logging
 
 sdns://AQcAAAAAAAAAIVsyYTAzOmIwYzA6MDoxMDEwOjplOWE6MzAwMV06NTM1MyCzpZdpFFdbBInhn66cQ-Z5-vKMVxiXADF_e7SWKR-wlRwyLmRuc2NyeXB0LWNlcnQuc2VjdXJlZG5zLmV1
 
+## securedns-doh
+
+Uncensored and no logging
+
+sdns://AgcAAAAAAAAADjE0Ni4xODUuMTY3LjQzABBkb2guc2VjdXJlZG5zLmV1Ci9kbnMtcXVlcnk
+
 ## sfw.scaleway-fr
 
 Uses deep learning to block adult websites. Free, DNSSEC, no logs.


### PR DESCRIPTION
The stamp is already published on SecureDNS website for a long times, but I haven't see it in public-resolvers.md, so I decided to add it into this list.