### PR TITLE
Add - Cloudflare DNS Resolver for Tor

### DIFF
--- a/v2/public-resolvers.md
+++ b/v2/public-resolvers.md
@@ -202,6 +202,14 @@ Cloudflare DNS over IPv6 (anycast)
 
 sdns://AgcAAAAAAAAAGVsyNjA2OjQ3MDA6NDcwMDo6MTExMV06NTOgENk8mGSlIfMGXMOlIlCcKvq7AVgcrZxtjon911-ep0cg63Ul-I8NlFj4GplQGb_TTLiczclX57DvMV8Q-JdjgRgSZG5zLmNsb3VkZmxhcmUuY29tCi9kbnMtcXVlcnk
 
+## cloudflare-onion
+
+Cloudflare DNS over tor (hidden service v3) 
+
+Provided by: https://blog.cloudflare.com/welcome-hidden-resolver/  https://dns4torpnlfs2ifuz2s2yf3fc7rdmsbhm6rw75euj35pac6ap25zgqad.onion/
+
+sdns://AgcAAAAAAAAAACC0WWFtenR5met-s8i0oiShMtYstulWSybPBq-zBUEMNT5kbnM0dG9ycG5sZnMyaWZ1ejJzMnlmM2ZjN3JkbXNiaG02cnc3NWV1ajM1cGFjNmFwMjV6Z3FhZC5vbmlvbgovZG5zLXF1ZXJ5
+
 ## commons-host
 
 DoH server by the Commons Host CDN


### PR DESCRIPTION
just needs config line:
`fallback_resolver = '127.0.0.1:9050'`


Fixes Issue: [#750](https://github.com/jedisct1/dnscrypt-proxy/issues/750)

[Reference](https://blog.cloudflare.com/welcome-hidden-resolver/)
[
![image](https://user-images.githubusercontent.com/46166740/56089594-8d94fb80-5e95-11e9-81fe-0d089952d8dc.png)
](https://blog.cloudflare.com/content/images/2018/06/tor.gif)

![image](https://user-images.githubusercontent.com/46166740/56089620-f11f2900-5e95-11e9-8308-d95f2130a647.png)
