### PR TITLE
add doh.appliedprivacy.net

### DIFF
--- a/v2/public-resolvers.md
+++ b/v2/public-resolvers.md
@@ -76,6 +76,15 @@ Remove ads and protect your computer from malware
 
 sdns://AQMAAAAAAAAAGVsyYTAwOjVhNjA6OmFkMjowZmZdOjU0NDMggdAC02pMpQxHO3R5ZQ_hLgKzIcthOFYqII5APf3FXpQiMi5kbnNjcnlwdC5kZWZhdWx0Lm5zMi5hZGd1YXJkLmNvbQ
 
+## doh.appliedprivacy.net
+
+Public DoH resolver operated by the Foundation for Applied Privacy (https://appliedprivacy.net).
+Hosted in Vienna, Austria.
+
+Non-logging, non-filtering, supports DNSSEC.
+
+sdns://AgcAAAAAAAAAAAAWZG9oLmFwcGxpZWRwcml2YWN5Lm5ldAYvcXVlcnk
+
 ## arvind-io
 
 Public resolver by EnKrypt (https://arvind.io).


### PR DESCRIPTION
Hi,

we would like to add our DNS-over-HTTPS resolver to the list.

We didn't fill the IP address and hash field when generating the stamp,
so we are more flexible to point the hostname "doh.appliedprivacy.net" to another IP address should there bee the need or switch to a new certificate authority.

Is the empty hash field supported or does that make it vulnerable to MITM attacks?

(TLS verification should take place via the usual publicly trusted CA)