### PR TITLE
add hashes for doh.appliedprivacy.net

### DIFF
--- a/v2/public-resolvers.md
+++ b/v2/public-resolvers.md
@@ -83,7 +83,7 @@ Hosted in Vienna, Austria.
 
 Non-logging, non-filtering, supports DNSSEC.
 
-sdns://AgcAAAAAAAAAAAAWZG9oLmFwcGxpZWRwcml2YWN5Lm5ldAYvcXVlcnk
+sdns://AgcAAAAAAAAAAKA-GhoPbFPz6XpJLVcIS1uYBwWe4FerFQWHb9g_2j24OKBoo-sB-l8CxNNfOhHQBMrwiyJL7qfXnFiMfxPIYTNgLqDvR4Wu5wydV1_nM4MG2T6nlhHl_tzvU2LdZsmLYLstvSAcVDa2UaK1QVwWz9ltGpcJ_ZyPJ-73XPlz2YL_5o5Y8BZkb2guYXBwbGllZHByaXZhY3kubmV0Bi9xdWVyeQ
 
 ## arvind-io
 


### PR DESCRIPTION
restrict CAs for doh.appliedprivacy.net to:
https://letsencrypt.org/certificates/#intermediate-certificates

hashes got generated via:

curl -s https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem.txt |openssl asn1parse  -out -|dd skip=4 bs=1 count=894|sha256sum
3e1a1a0f6c53f3e97a492d57084b5b9807059ee057ab1505876fd83fda3db838

curl -s https://letsencrypt.org/certs/letsencryptauthorityx3.pem.txt|openssl asn1parse -out - |dd skip=4 bs=1 count=889|sha256sum
68a3eb01fa5f02c4d35f3a11d004caf08b224beea7d79c588c7f13c86133602e

curl -s https://letsencrypt.org/certs/lets-encrypt-x4-cross-signed.pem.txt |openssl asn1parse  -out -|dd skip=4 bs=1 count=894|sha256sum
ef4785aee70c9d575fe7338306d93ea79611e5fedcef5362dd66c98b60bb2dbd

curl -s https://letsencrypt.org/certs/letsencryptauthorityx4.pem.txt |openssl asn1parse -out - |dd skip=4 bs=1 count=889|sha256sum
1c5436b651a2b5415c16cfd96d1a9709fd9c8f27eef75cf973d982ffe68e58f0