### PR TITLE
Adds captnemo-in-doh

### DIFF
--- a/v2/public-resolvers.md
+++ b/v2/public-resolvers.md
@@ -115,12 +115,21 @@ sdns://AQcAAAAAAAAAEzE3OC4xMjguMjU1LjI4OjUzNTMgkr1k-Lp2d9IXiFlXoBAgFGZUCJSPW_x81
 
 ## captnemo-in
 
-Server running out of a Digital Ocean droplet in BLR1 region.
+Server running out of a Digital Ocean droplet in Bangalore.
 Maintained by Abhay Rana aka Nemo.
 
-If you are within India, this might be a nice DNS server to use.
+If you are within India, this might be a nice DNS server to use. See [Privacy Policy](https://captnemo.in/dns/privacy/).
 
-sdns://AQQAAAAAAAAAEjEzOS41OS40OC4yMjI6NDQzNCAFOt_yxaMpFtga2IpneSwwK6rV0oAyleham9IvhoceEBsyLmRuc2NyeXB0LWNlcnQuY2FwdG5lbW8uaW4
+sdns://AQcAAAAAAAAAEjEzOS41OS40OC4yMjI6NDQzNCAFOt_yxaMpFtga2IpneSwwK6rV0oAyleham9IvhoceEBsyLmRuc2NyeXB0LWNlcnQuY2FwdG5lbW8uaW4
+
+## captnemo-in-doh
+
+Server running out of a Digital Ocean droplet in Bangalore.
+Maintained by Abhay Rana aka Nemo.
+
+If you are within India, this might be a nice DoH server to use. See [Privacy Policy](https://captnemo.in/dns/privacy/).
+
+sdns://AgcAAAAAAAAADTEzOS41OS40OC4yMjIgJYR9Zo608E_dQLErawdAxWfafQJDCOtsLJb-QdneIY0PZG9oLmNhcHRuZW1vLmluCi9kbnMtcXVlcnk
 
 ## charis
 


### PR DESCRIPTION
- Adds captnemo-in-doh resolver
- Links to Privacy policy for both resolvers (captnemo-in*)
- Confirms DNSSEC/No Logging/No filtering on the DNS Stamp

For the DNS Stamp (DoH Resolver)  I've used the LetsEncrypt X3 certificate in the hash parameter (`25847d668eb4f04fdd40b12b6b0740c567da7d024308eb6c2c96fe41d9de218d` = SHA256 for the LE X3 Certificate). Is that a good idea?