### PR TITLE
add dns.digitale-gesellschaft.ch

### DIFF
--- a/v2/public-resolvers.md
+++ b/v2/public-resolvers.md
@@ -207,6 +207,15 @@ By https://cleanbrowsing.org/
 
 sdns://AQMAAAAAAAAAFFsyYTBkOjJhMDA6MTo6XTo4NDQzILysMvrVQ2kXHwgy1gdQJ8MgjO7w6OmflBjcd2Bl1I8pEWNsZWFuYnJvd3Npbmcub3Jn
 
+## dns.digitale-gesellschaft.ch
+
+Public DoH resolver operated by the Digital Society (https://www.digitale-gesellschaft.ch).
+Hosted in Zurich, Switzerland.
+
+Non-logging, non-filtering, supports DNSSEC.
+
+sdns://AgcAAAAAAAAAAKA-GhoPbFPz6XpJLVcIS1uYBwWe4FerFQWHb9g_2j24OKBoo-sB-l8CxNNfOhHQBMrwiyJL7qfXnFiMfxPIYTNgLqDvR4Wu5wydV1_nM4MG2T6nlhHl_tzvU2LdZsmLYLstvSAcVDa2UaK1QVwWz9ltGpcJ_ZyPJ-73XPlz2YL_5o5Y8BxkbnMuZGlnaXRhbGUtZ2VzZWxsc2NoYWZ0LmNoCi9kbnMtcXVlcnk
+
 ## dnscrypt.ca-1
 
 Free, Canadian, uncensored, no-logs, encrypted, and DNSSEC validated


### PR DESCRIPTION
Hey

We'd like to add our public DoH resolver to the list.

restrict CAs for dns.digitale-gesellschaft.ch to:
https://letsencrypt.org/certificates/#intermediate-certificates

hashes got generated via:

    curl -s https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem.txt |openssl asn1parse -out -|dd skip=4 bs=1 count=894|sha256sum 
3e1a1a0f6c53f3e97a492d57084b5b9807059ee057ab1505876fd83fda3db838

    curl -s https://letsencrypt.org/certs/letsencryptauthorityx3.pem.txt|openssl asn1parse -out - |dd skip=4 bs=1 count=889|sha256sum 
68a3eb01fa5f02c4d35f3a11d004caf08b224beea7d79c588c7f13c86133602e

    curl -s https://letsencrypt.org/certs/lets-encrypt-x4-cross-signed.pem.txt |openssl asn1parse -out -|dd skip=4 bs=1 count=894|sha256sum 
ef4785aee70c9d575fe7338306d93ea79611e5fedcef5362dd66c98b60bb2dbd

    curl -s https://letsencrypt.org/certs/letsencryptauthorityx4.pem.txt |openssl asn1parse -out - |dd skip=4 bs=1 count=889|sha256sum 
1c5436b651a2b5415c16cfd96d1a9709fd9c8f27eef75cf973d982ffe68e58f0

Thank you for reviewing this request.