### PR TITLE
Add developer.li opennic dns servers

### DIFF
--- a/v2/opennic.md
+++ b/v2/opennic.md
@@ -99,3 +99,67 @@ sdns://AgcAAAAAAAAADTEzOS45OS4yMjIuNzIgPhoaD2xT8-l6SS1XCEtbmAcFnuBXqxUFh2_YP9o9u
 Non-logging OpenNIC resolver in France
 
 sdns://AQYAAAAAAAAAETE1MS44MC4yMjIuNzk6NDQzIO4Y9lZnORlvodxu39dnm6mFruwTRnlmovbEga4Fyw3TIDIuZG5zY3J5cHQtY2VydC5vcGVubmljLmkycGQueHl6
+
+## developerli-fr
+
+DNSSEC - OpenNIC - Non-logging - Uncensored - hosted on ovh.com
+Location: Gravelines, France.
+Maintained by piraces - https://developer.li
+
+sdns://AQcAAAAAAAAADjE2NC4xMzIuNDUuMTEyIJjcR4lfaiSu1VnGEUxuFHjZAJMtzh4IIzY1nENSdINmIDIuZG5zY3J5cHQtY2VydC5uczEuZGV2ZWxvcGVyLmxp
+
+## developerli-fr-ipv6
+
+DNSSEC - OpenNIC - Non-logging - Uncensored - hosted on ovh.com
+Location: Gravelines, France.
+Maintained by piraces - https://developer.li
+
+sdns://AQcAAAAAAAAAFzIwMDE6NDFkMDozMDI6MjIwMDo6NzM1IOORyBsbVECZjBLtBBPcvz4BX6KqFLyBHOgRFnPjDc91IDIuZG5zY3J5cHQtY2VydC5uczEuZGV2ZWxvcGVyLmxp
+
+## developerli-de
+
+DNSSEC - OpenNIC - Non-logging - Uncensored - hosted on ovh.com
+Location: Limburg, Germany.
+Maintained by piraces - https://developer.li
+
+sdns://AQcAAAAAAAAACzUxLjg5LjIyLjM2IFCr7Cwmkxqhwih6Yd6DXna4QnD43eEobcm4jYfdOKGQIDIuZG5zY3J5cHQtY2VydC5uczIuZGV2ZWxvcGVyLmxp
+
+## developerli-de-ipv6
+
+DNSSEC - OpenNIC - Non-logging - Uncensored - hosted on ovh.com
+Location: Limburg, Germany.
+Maintained by piraces - https://developer.li
+
+sdns://AQcAAAAAAAAAGDIwMDE6NDFkMDo3MDE6MTEwMDo6MjFiNSBF27xjwGrNk7IfBlWNxDMfThgQaJl-G-B6V-ORq6ZblSAyLmRuc2NyeXB0LWNlcnQubnMyLmRldmVsb3Blci5saQ
+
+## developerli-fr-doh
+
+DNSSEC - OpenNIC - Non-logging - Uncensored - hosted on ovh.com
+Location: Gravelines, France.
+Maintained by piraces - https://developer.li
+
+sdns://AgcAAAAAAAAADjE2NC4xMzIuNDUuMTEyABVkbnMuZGV2ZWxvcGVyLmxpOjg0NDMKL2Rucy1xdWVyeQ
+
+## developerli-fr-doh-ipv6
+
+DNSSEC - OpenNIC - Non-logging - Uncensored - hosted on ovh.com
+Location: Gravelines, France.
+Maintained by piraces - https://developer.li
+
+sdns://AgcAAAAAAAAAFzIwMDE6NDFkMDozMDI6MjIwMDo6NzM1ABVkbnMuZGV2ZWxvcGVyLmxpOjg0NDMKL2Rucy1xdWVyeQ
+
+## developerli-de-doh
+
+DNSSEC - OpenNIC - Non-logging - Uncensored - hosted on ovh.com
+Location: Limburg, Germany.
+Maintained by piraces - https://developer.li
+
+sdns://AgcAAAAAAAAACzUxLjg5LjIyLjM2ABZkbnMyLmRldmVsb3Blci5saTo4NDQzCi9kbnMtcXVlcnk
+
+## developerli-de-doh-ipv6
+
+DNSSEC - OpenNIC - Non-logging - Uncensored - hosted on ovh.com
+Location: Limburg, Germany.
+Maintained by piraces - https://developer.li
+
+sdns://AgcAAAAAAAAAGDIwMDE6NDFkMDo3MDE6MTEwMDo6MjFiNQAWZG5zMi5kZXZlbG9wZXIubGk6ODQ0MwovZG5zLXF1ZXJ5


### PR DESCRIPTION
This PR adds two new public DNS Servers located in France & Germany.
Both servers listen on IPv4 and IPv6 addresses, providing DoH and DNSCrypt services.