### PR TITLE
Adding DoH Servers of Freifunk Muenchen

### DIFF
--- a/v2/public-resolvers.md
+++ b/v2/public-resolvers.md
@@ -895,13 +895,12 @@ sdns://AgcAAAAAAAAAACA-GhoPbFPz6XpJLVcIS1uYBwWe4FerFQWHb9g_2j24OA9yZG5zLmZhZWxpe
 
 An open DoH resolver operated by Freifunk Munich with nodes in DE.
 
-sdns://AgYAAAAAAAAADDE5NS4zMC45NC4yOAANZG9oLmZmbXVjLm5ldAEv
-
+sdns://AgYAAAAAAAAADDE5NS4zMC45NC4yOAANZG9oLmZmbXVjLm5ldAovZG5zLXF1ZXJ5
 ## doh.ffmuc.net-v6
 
 An open DoH resolver operated by Freifunk Munich with nodes in DE.
 
-sdns://AgYAAAAAAAAADzIwMDE6NjA4OmEwMTo6MwANZG9oLmZmbXVjLm5ldAEv
+sdns://AgYAAAAAAAAADzIwMDE6NjA4OmEwMTo6MwANZG9oLmZmbXVjLm5ldAovZG5zLXF1ZXJ5
 
 ## freetsa.org
 


### PR DESCRIPTION
Adding doh.ffmuc.net which provide DoH without logging and filtering.
- Confirms No Logging/No filtering on the DNS Stamp
- runs DNSDist

I am unsure, how to provide the hash with Letsencrypt certificates. 