### PR TITLE
Please remove our public resolver from the list

### DIFF
--- a/v2/public-resolvers.md
+++ b/v2/public-resolvers.md
@@ -22,12 +22,6 @@ To use that list, add this to the `[sources]` section of your
 
 --
 
-## 42l
-
-DNS resolver of the associative French ISP FDN accessible over DoH.
-DNSSEC-enabled. Proxies to Google DNS. https://42l.fr/
-sdns://AgcAAAAAAAAADjE4NS4yMTYuMjcuMTQyID4aGg9sU_PpekktVwhLW5gHBZ7gV6sVBYdv2D_aPbg4CmRvaC40MmwuZnIKL2Rucy1xdWVyeQ
-
 ## aaflalo-me-nyc
 
 DNS-over-HTTPS server running dns-over-https with PiHole for Adblocking in NYC, USA.


### PR DESCRIPTION
Hello,

>DNS resolver of the associative French ISP FDN accessible over DoH.

We aren't the French ISP FDN at all. We are hosting an instance of `doh-proxy` (by jedisct1) that redirects DoH queries we're receiving to FDN's open DNS resolver, but we are a fully separate entity.

> Proxies to Google DNS.

We've never proxied anything to Google DNS.

More information here: https://42l.fr/Service-DoH
(you might not be able to access the page if you're using dnscrypt-proxy)

We've been suffering from an *heavy* traffic from dnscrypt-proxy users. Our little infrastructure isn't ready to have its place on this list.

We'd be glad if you can remove our proxy from it.

As a proof we're not impersonating the association, we sent an encrypted email signed with our PGP key to jedisct1's pureftpd address (sorry, was it the wrong one?).
You can check our PGP key here : https://42l.fr/Contact

Thanks for your understanding.