### PR TITLE
Add anon-publicarray

### DIFF
--- a/v2/relays.md
+++ b/v2/relays.md
@@ -41,3 +41,9 @@ sdns://gSBbMjQwMDo2MTgwOjA6ZDA6OjVmNzM6NDAwMV06MTQ0Mw
 Anonymized DNS relay provided by evilvibes.com Location: Vancouver, Canada
 
 sdns://gQ4xMDQuMzYuMTQ5LjE3Nw
+
+## anon-publicarray
+
+Anonymized DNS relay hosted in Sydney, Australia and maintained by Sebastian Schmidt (@publicarray)
+
+sdns://gRIxMzkuOTkuMjIyLjcyOjg0NDM


### PR DESCRIPTION
Hope I'm not too late to join the party!

BTW I have made a copy of the docker image but without unbound. My idea was to closer match the the docker philosophy of one service per container: https://github.com/publicarray/dns-resolver-infra/tree/master/dnscrypt-server. It also makes easier to swap out the DNS backed if people desire.