### PR TITLE
add sdns://gRIxMDQuMjM4LjE1My40Njo0NDM

### DIFF
--- a/v2/relays.md
+++ b/v2/relays.md
@@ -57,7 +57,7 @@ sdns://gRMxNjMuMTcyLjE4MC4xMjU6NDQz
 
 ## anon-inconnu
 
-Anonymized DNS relay hosted in Seattle (USA) running dnscrypt-server-docker on
-Vultr.
+Anonymized DNS relay hosted in Seattle, WA (USA). Running the official Docker
+image on Vultr.
 
 sdns://gRIxMDQuMjM4LjE1My40Njo0NDM

--- a/v2/relays.md
+++ b/v2/relays.md
@@ -54,3 +54,10 @@ Anonymized DNS relay hosted in France and maintained by Frank Denis (@jedisct1).
 Running on an instance donated by https://scaleway.com
 
 sdns://gRMxNjMuMTcyLjE4MC4xMjU6NDQz
+
+## anon-inconnu
+
+Anonymized DNS relay hosted in Seattle (USA) running dnscrypt-server-docker on
+Vultr.
+
+sdns://gRIxMDQuMjM4LjE1My40Njo0NDM


### PR DESCRIPTION
```
$ cat /etc/motd
[INFO ] State file [/opt/encrypted-dns/etc/keys/state/encrypted-dns.state] found; using existing provider key
[INFO ] Public server address: 104.238.153.46:443
[INFO ] Provider public key: a4ecf2c145bea706353acf6d24443d2fbb486442a5665c038acd50457b0dfb68
[INFO ] Provider name: 2.dnscrypt-cert.dns.inconnu.club
[INFO ] DNS Stamp: sdns://AQcAAAAAAAAAEjEwNC4yMzguMTUzLjQ2OjQ0MyCk7PLBRb6nBjU6z20kRD0vu0hkQqVmXAOKzVBFew37aCAyLmRuc2NyeXB0LWNlcnQuZG5zLmluY29ubnUuY2x1Yg
[INFO ] DNS Stamp for Anonymized DNS relaying: sdns://gRIxMDQuMjM4LjE1My40Njo0NDM
```