### PR TITLE
Updated pi-dns.com servers

### DIFF
--- a/v2/public-resolvers.md
+++ b/v2/public-resolvers.md
@@ -1153,16 +1153,16 @@ sdns://AgMAAAAAAAAAF1syYTAxOjRmODoxYzFjOjZiNGI6OjFdABJkb2gtZGUuYmxhaGRucy5jb20KL
 
 ## doh-eastus-pi-dns
 
-Public Pi-hole DNS with DoH support. Blocks ads and trackers. No persistent logs, DNSSEC, Hosted in New York. By https://pi-dns.com/
-Server status can be seen at: https://eastus.pi-dns.com/
+Public Pi-hole DNS with DoH support. Blocks ads and trackers. No persistent logs, DNSSEC, Hosted in New York, USA. By https://pi-dns.com/
+Server status can be seen at: https://pi-dns.com/
 
 sdns://AgMAAAAAAAAADjE4NS4yMTMuMjYuMTg3ID4aGg9sU_PpekktVwhLW5gHBZ7gV6sVBYdv2D_aPbg4FWRvaC5lYXN0dXMucGktZG5zLmNvbQovZG5zLXF1ZXJ5
 
 
 ## doh-eastus-pi-dns-ipv6
 
-Public Pi-hole DNS with DoH support. Blocks ads and trackers. No persistent logs, DNSSEC, Hosted in New York. By https://pi-dns.com/
-Server status can be seen at: https://eastus.pi-dns.com/
+Public Pi-hole DNS with DoH support. Blocks ads and trackers. No persistent logs, DNSSEC, Hosted in New York, USA. By https://pi-dns.com/
+Server status can be seen at: https://pi-dns.com/
 
 sdns://AgMAAAAAAAAAFlsyYTBkOjU2MDA6MzM6Mzo6YWJjZF0gPhoaD2xT8-l6SS1XCEtbmAcFnuBXqxUFh2_YP9o9uDgVZG9oLmVhc3R1cy5waS1kbnMuY29tCi9kbnMtcXVlcnk
 
@@ -1221,48 +1221,48 @@ sdns://AgMAAAAAAAAAKVsyMDAxOjE5ZjA6NzAwMTozMjU5OjU0MDA6MDJmZjpmZTcxOjBiYzldABJkb
 
 ## doh-northeu-pi-dns
 
-Public Pi-hole DNS with DoH support. Blocks ads and trackers. No persistent logs, DNSSEC, Hosted in Helsinki. By https://pi-dns.com/
-Server status can be seen at: https://northeu.pi-dns.com/
+Public Pi-hole DNS with DoH support. Blocks ads and trackers. No persistent logs, DNSSEC, Hosted in Helsinki, Finland. By https://pi-dns.com/
+Server status can be seen at: https://pi-dns.com/
 
 sdns://AgMAAAAAAAAADjk1LjIxNi4xODEuMjI4ID4aGg9sU_PpekktVwhLW5gHBZ7gV6sVBYdv2D_aPbg4FmRvaC5ub3J0aGV1LnBpLWRucy5jb20KL2Rucy1xdWVyeQ
 
 
 ## doh-northeu-pi-dns-ipv6
 
-Public Pi-hole DNS with DoH support. Blocks ads and trackers. No persistent logs, DNSSEC, Hosted in Helsinki. By https://pi-dns.com/
-Server status can be seen at: https://northeu.pi-dns.com/
+Public Pi-hole DNS with DoH support. Blocks ads and trackers. No persistent logs, DNSSEC, Hosted in Helsinki, Finland. By https://pi-dns.com/
+Server status can be seen at: https://pi-dns.com/
 
 sdns://AgMAAAAAAAAAF1syYTAxOjRmOTpjMDFmOjQ6OmFiY2RdID4aGg9sU_PpekktVwhLW5gHBZ7gV6sVBYdv2D_aPbg4FmRvaC5ub3J0aGV1LnBpLWRucy5jb20KL2Rucy1xdWVyeQ
 
 
-## doh-westeu-pi-dns
+## doh-centraleu-pi-dns
 
-Public Pi-hole DNS with DoH support. Blocks ads and trackers. No persistent logs, DNSSEC, Hosted in Netherlands. By https://pi-dns.com/
-Server status can be seen at: https://westeu.pi-dns.com/
+Public Pi-hole DNS with DoH support. Blocks ads and trackers. No persistent logs, DNSSEC, Hosted in Nuremberg, Germany. By https://pi-dns.com/
+Server status can be seen at: https://pi-dns.com/
 
-sdns://AgMAAAAAAAAADDMxLjIyMC40Mi42NSA-GhoPbFPz6XpJLVcIS1uYBwWe4FerFQWHb9g_2j24OBVkb2gud2VzdGV1LnBpLWRucy5jb20KL2Rucy1xdWVyeQ
+sdns://AgMAAAAAAAAADTg4LjE5OC45MS4xODcgPhoaD2xT8-l6SS1XCEtbmAcFnuBXqxUFh2_YP9o9uDgYZG9oLmNlbnRyYWxldS5waS1kbnMuY29tCi9kbnMtcXVlcnk
 
 
-## doh-westeu-pi-dns-ipv6
+## doh-centraleu-pi-dns-ipv6
 
-Public Pi-hole DNS with DoH support. Blocks ads and trackers. No persistent logs, DNSSEC, Hosted in Netherlands. By https://pi-dns.com/
-Server status can be seen at: https://westeu.pi-dns.com/
+Public Pi-hole DNS with DoH support. Blocks ads and trackers. No persistent logs, DNSSEC, Hosted in Nuremberg, Germany. By https://pi-dns.com/
+Server status can be seen at: https://pi-dns.com/
 
-sdns://AgMAAAAAAAAAGFsyYTAxOjZmMDpmZmZmOjQ5OjphYmNkXSA-GhoPbFPz6XpJLVcIS1uYBwWe4FerFQWHb9g_2j24OBVkb2gud2VzdGV1LnBpLWRucy5jb20KL2Rucy1xdWVyeQ
+sdns://AgMAAAAAAAAAF1syYTAxOjRmODoxYzBjOjgyMzM6OjFdID4aGg9sU_PpekktVwhLW5gHBZ7gV6sVBYdv2D_aPbg4GGRvaC5jZW50cmFsZXUucGktZG5zLmNvbQovZG5zLXF1ZXJ5
 
 
 ## doh-westus-pi-dns
 
-Public Pi-hole DNS with DoH support. Blocks ads and trackers. No persistent logs, DNSSEC, Hosted in Los Angeles. By https://pi-dns.com/
-Server status can be seen at: https://westus.pi-dns.com/
+Public Pi-hole DNS with DoH support. Blocks ads and trackers. No persistent logs, DNSSEC, Hosted in Los Angeles, USA. By https://pi-dns.com/
+Server status can be seen at: https://pi-dns.com/
 
 sdns://AgMAAAAAAAAADTQ1LjY3LjIxOS4yMDggPhoaD2xT8-l6SS1XCEtbmAcFnuBXqxUFh2_YP9o9uDgVZG9oLndlc3R1cy5waS1kbnMuY29tCi9kbnMtcXVlcnk
 
 
 ## doh-westus-pi-dns-ipv6
 
-Public Pi-hole DNS with DoH support. Blocks ads and trackers. No persistent logs, DNSSEC, Hosted in Los Angeles. By https://pi-dns.com/
-Server status can be seen at: https://westus.pi-dns.com/
+Public Pi-hole DNS with DoH support. Blocks ads and trackers. No persistent logs, DNSSEC, Hosted in Los Angeles, USA. By https://pi-dns.com/
+Server status can be seen at: https://pi-dns.com/
 
 sdns://AgMAAAAAAAAAGFsyYTA0OmJkYzc6MTAwOjcwOjphYmNkXSA-GhoPbFPz6XpJLVcIS1uYBwWe4FerFQWHb9g_2j24OBVkb2gud2VzdHVzLnBpLWRucy5jb20KL2Rucy1xdWVyeQ
 

--- a/v2/public-resolvers.md
+++ b/v2/public-resolvers.md
@@ -498,7 +498,7 @@ Remove your DNS blind spot
 Warning: modifies your queries to include a copy of your network
 address when forwarding them to a selection of companies and organizations.
 
-sdns://AQAAAAAAAAAADjIwOC42Ny4yMjAuMjIwILc1EUAgbyJdPivYItf9aR6hwzzI1maNDL4Ev6vKQ_t5GzIuZG5zY3J5cHQtY2VydC5vcGVuZG5zLmNvbQ
+sdns://AQEAAAAAAAAADDIwOC42Ny4yMjAuMiC3NRFAIG8iXT4r2CLX_WkeocM8yNZmjQy-BL-rykP7eRsyLmRuc2NyeXB0LWNlcnQub3BlbmRucy5jb20
 
 
 ## cisco-familyshield
@@ -518,7 +518,7 @@ Cisco OpenDNS IPv6 sandbox
 Warning: modifies your queries to include a copy of your network
 address when forwarding them to a selection of companies and organizations.
 
-sdns://AQAAAAAAAAAAD1syNjIwOjA6Y2NjOjoyXSC3NRFAIG8iXT4r2CLX_WkeocM8yNZmjQy-BL-rykP7eRsyLmRuc2NyeXB0LWNlcnQub3BlbmRucy5jb20
+sdns://AQEAAAAAAAAAD1syNjIwOjA6Y2NjOjoyXSC3NRFAIG8iXT4r2CLX_WkeocM8yNZmjQy-BL-rykP7eRsyLmRuc2NyeXB0LWNlcnQub3BlbmRucy5jb20
 
 
 ## cleanbrowsing-adult

--- a/v2/public-resolvers.md.minisig
+++ b/v2/public-resolvers.md.minisig
@@ -1,4 +1,4 @@
 untrusted comment: signature from minisign secret key
-RWQf6LRCGA9i59VL5r21NbzAjk8EBUAjWWx1880IjH/Nuv1sBQ6zz6FSrTFPviGzWAgAYuPrx+UMGQGzXD9e1AhFai/I8bxFXQ8=
-trusted comment: timestamp:1581264627	file:public-resolvers.md
-DsdUBtolamFKVnQLlWdt/RbpY5CEjubmxfbzI3kiiKETStfq3SUX2WZjg+SWmtAGrcjAdxixDRTqh81/4L2pAQ==
+RWQf6LRCGA9i51Jq67W67RIe+nj4nYuwW3nknw2sVEpIdrmC2GbjGaCv3ROm/e2ilZwCX5BpTwk+QUgkxZTGrA1Ao+l8kKD2Owk=
+trusted comment: timestamp:1581377359	file:public-resolvers.md
+ZHlSbSgOclcTy8ixAlYn+WqE/Q4Xj6r0C02r9TmCVXlkgVhS+51E51I99k8xDT1B7X1QAatyZje6Kje6ypgDCw==


### PR DESCRIPTION
# PR: Updated pi-dns.com servers
## Summary
1. Updated description of all pi-dns servers to include both city and country.
2. Changed pi-dns WestEU server to new CentralEU server. New DNS-Stamps.

### Reason for PR
 pi-dns have moved the west europe server to central europe. This lead to new ip addresses and as such, new DNS stamps. The "old" west europe server will be online for quite some time before being shut down but it's good to get users to move over asap.