### PR TITLE
Added relay  anon-sth-se

### DIFF
--- a/v2/relays.md
+++ b/v2/relays.md
@@ -240,6 +240,13 @@ IPv6 only.
 sdns://gRtbMjAwMTpiYzg6MTgyNDoxNzBmOjoxXTo0NDM
 
 
+## anon-sth-se
+
+Anonymized DNS relay hosted in Sweden.
+
+sdns://gRE0NS4xNTMuMTg3Ljk2OjQ0Mw
+
+
 ## anon-tiarap
 
 Anonymized DNS relay hosted in Singapore


### PR DESCRIPTION
Updated dnsdist server to 1.5, should accept UDP datagrams larger than 1500 bytes.

## anon-sth-se

Anonymized DNS relay hosted in Sweden.

sdns://gRE0NS4xNTMuMTg3Ljk2OjQ0Mw