### PR TITLE
remove Cloudflare Onion Service

### DIFF
--- a/v2/onion-services.md
+++ b/v2/onion-services.md
@@ -19,8 +19,3 @@ To use that list, add this to the `[sources]` section of your
 --
 
 
-## onion-cloudflare
-
-Cloudflare Onion Service
-
-sdns://AgcAAAAAAAAAACC0WWFtenR5met-s8i0oiShMtYstulWSybPBq-zBUEMNT5kbnM0dG9ycG5sZnMyaWZ1ejJzMnlmM2ZjN3JkbXNiaG02cnc3NWV1ajM1cGFjNmFwMjV6Z3FhZC5vbmlvbgovZG5zLXF1ZXJ5


### PR DESCRIPTION
Certificate fails since April

`dnscrypt-proxy: [ERROR] Get "https://dns4torpnlfs2ifuz2s2yf3fc7rdmsbhm6rw75euj35pac6ap25zgqad.onion/dns-query?ct=&dns=yv4BAAABAAAAAAABAAACAAEAACkQAAAAAAAAFAAMABDNluS_h5fKQgqu5p2e1_ui": x509: certificate is valid for cloudflare-dns.com, *.cloudflare-dns.com, one.one.one.one, not dns4torpnlfs2ifuz2s2yf3fc7rdmsbhm6rw75euj35pac6ap25zgqad.onion`