### PR TITLE
Add DeCloudUs DNS resolver

### DIFF
--- a/v2/public-resolvers.md
+++ b/v2/public-resolvers.md
@@ -600,6 +600,21 @@ Server provided by Martin 'd0wn' Albus
 
 sdns://AQcAAAAAAAAAGFsyYzBmOmZkYTg6NTo6MmVkMTpkMmVjXSDWBhX70UU7oU52ij5cXLOsF0YTMUY9oK-M998E2k11bRsyLmRuc2NyeXB0LWNlcnQudHouZDB3bi5iaXo
 
+## decloudus-nogoogle-tst
+
+Servers helps you deGoogle and unGoogle by completely blocking Google tracking in addition to annoying ads, online trackers, and malware. Supports DNSSEC. No Logs.
+
+Contributed by: https://decloudus.com
+
+sdns://AQMAAAAAAAAAEjE3Ni45LjE5OS4xNTg6ODQ0MyD73Ye9XeCsS7TdFu9fRP7s5k-0aL91yygulGVmeOAKLh4yLmRuc2NyeXB0LWNlcnQuRGVDbG91ZFVzLXRlc3Q
+
+
+## decloudus-nogoogle-tstipv6
+
+Servers helps you deGoogle and unGoogle by completely blocking Google tracking in addition to annoying ads, online trackers, and malware. Supports DNSSEC. No Logs. For IPv6.
+
+Contributed by: https://decloudus.com
+
 
 ## dns.digitale-gesellschaft.ch
 

--- a/v2/public-resolvers.md
+++ b/v2/public-resolvers.md
@@ -615,6 +615,8 @@ Servers helps you deGoogle and unGoogle by completely blocking Google tracking i
 
 Contributed by: https://decloudus.com
 
+sdns://AQMAAAAAAAAAG1syYTAxOjRmODoxNTE6MTFiMDo6M106ODQ0MyD73Ye9XeCsS7TdFu9fRP7s5k-0aL91yygulGVmeOAKLh4yLmRuc2NyeXB0LWNlcnQuRGVDbG91ZFVzLXRlc3Q 
+
 
 ## dns.digitale-gesellschaft.ch
 


### PR DESCRIPTION
Public DNS resolver by https://decloudus.com to help community deGoogle and unGoogle by completely blocking Google tracking in addition to annoying ads, online trackers, and malware. Supports DNSSEC. No Logs.