### PR TITLE
New resolvers in Spain.

### DIFF
--- a/v3/onion-services.md
+++ b/v3/onion-services.md
@@ -12,7 +12,7 @@ To use that list, add this to the `[sources]` section of your
 `dnscrypt-proxy.toml` configuration file:
 
     [sources.'onion-services']
-    urls = ['https://raw.githubusercontent.com/DNSCrypt/dnscrypt-resolvers/master/v2/onion-services.md', 'https://download.dnscrypt.info/resolvers-list/v2/onion-services.md']
+    urls = ['https://raw.githubusercontent.com/DNSCrypt/dnscrypt-resolvers/master/v3/onion-services.md', 'https://download.dnscrypt.info/resolvers-list/v3/onion-services.md']
     minisign_key = 'RWQf6LRCGA9i53mlYecO4IzT51TGPpvWucNSCh1CBM0QTaLn73Y7GFO3'
     cache_file = 'onion-services.md'
 

--- a/v3/onion-services.md.minisig
+++ b/v3/onion-services.md.minisig
@@ -1,4 +1,4 @@
 untrusted comment: signature from minisign secret key
-RWQf6LRCGA9i50FioNSlB3OYxNCJYpIr/frciztqTvWHAa1uUmTN2l9F8ZKIa9kM5ixZTxmX1hlpCw229H5qLqq1ANo/HuwqiQ8=
-trusted comment: timestamp:1593348900	file:onion-services.md
-i3LmDW69epmr81rCry3q4MWYP79QYatGKsmLeHgD6VW5TTw/STDg8oMY8xAofWhmeqZMDpOSBrJ8rXLenkT0Aw==
+RWQf6LRCGA9i58kHF1Gg04lD/GflpXX7LsfD+d+oyVbkTux8QA5BUxOH0gg7HgP3FTV/orocEYcT/EPs7bxAFi6yPP+fjgqhiAY=
+trusted comment: timestamp:1593609508	file:onion-services.md
+gv8FNDXTux6CfcEBIMf9xelP9JwZTGFx0PzV+GXDbNctXQMMw7TwTY13CsKZIRKIzuYZKZ8DSvoM/BFjWkYIAA==

--- a/v3/opennic.md
+++ b/v3/opennic.md
@@ -6,7 +6,7 @@ To use that list, add this to the `[sources]` section of your
 `dnscrypt-proxy.toml` configuration file:
 
     [sources.'opennic']
-    urls = ['https://raw.githubusercontent.com/DNSCrypt/dnscrypt-resolvers/master/v2/opennic.md', 'https://download.dnscrypt.info/resolvers-list/v2/opennic.md']
+    urls = ['https://raw.githubusercontent.com/DNSCrypt/dnscrypt-resolvers/master/v3/opennic.md', 'https://download.dnscrypt.info/resolvers-list/v3/opennic.md']
     minisign_key = 'RWQf6LRCGA9i53mlYecO4IzT51TGPpvWucNSCh1CBM0QTaLn73Y7GFO3'
     cache_file = 'opennic.md'
 

--- a/v3/opennic.md.minisig
+++ b/v3/opennic.md.minisig
@@ -1,4 +1,4 @@
 untrusted comment: signature from minisign secret key
-RWQf6LRCGA9i5xLlTeDptDCf4Rn19jfvqA0kf9If+sWoZqZYYy/S99/AVhJKv3W88vbWfBxBBenCdHcwUYltJNIYwd7/trLZeg8=
-trusted comment: timestamp:1593348900	file:opennic.md
-hD/3UhwgOcLORLmSMrgMuOqGvNF2wFCvnLOOaf6iA2QbMO7X60s10K4DSKONBea2J8Xj9pn0vOpLfXdacBKdDw==
+RWQf6LRCGA9i5wpSu2xlCLkCm5YXKJoiVyLEbsEQCE1DTbOtOjMjlWSuYlSzWeduhA/Rx1VtFZYMFD7ws9l3J7xJOAngYL7yiQE=
+trusted comment: timestamp:1593609508	file:opennic.md
+6XO6xjdWyjxTy2wpxTlMjU1g82HTBgGHGeSCHy1gFIQeVkG/zvTVeclg6YWzefMWiJcwcamBkpskkKRsbEaiCw==

--- a/v3/parental-control.md
+++ b/v3/parental-control.md
@@ -10,7 +10,7 @@ To use that list, add this to the `[sources]` section of your
 `dnscrypt-proxy.toml` configuration file:
 
     [sources.'parental-control']
-    urls = ['https://raw.githubusercontent.com/DNSCrypt/dnscrypt-resolvers/master/v2/parental-control.md', 'https://download.dnscrypt.info/resolvers-list/v2/parental-control.md']
+    urls = ['https://raw.githubusercontent.com/DNSCrypt/dnscrypt-resolvers/master/v3/parental-control.md', 'https://download.dnscrypt.info/resolvers-list/v3/parental-control.md']
     minisign_key = 'RWQf6LRCGA9i53mlYecO4IzT51TGPpvWucNSCh1CBM0QTaLn73Y7GFO3'
     cache_file = 'parental-control.md'
 

--- a/v3/parental-control.md.minisig
+++ b/v3/parental-control.md.minisig
@@ -1,4 +1,4 @@
 untrusted comment: signature from minisign secret key
-RWQf6LRCGA9i5wrnlz7z9XbhYzUnhwO1mx8xFHYFkj82Um9uFTHAt1yUZCk5+BPgcnbIs1TfDxK89U3fn1vQ6qZ0PvYbbbvcJww=
-trusted comment: timestamp:1593498378	file:parental-control.md
-1WlGZrXtopbeIuo7jMAyyZgp/vPBo47I4I2ixm80MiH12wJGMGI/L6+GORRA/kVRUNsAC3h20LhNuMcsE5a3Cg==
+RWQf6LRCGA9i57pjrrjJ5pTpDdjroWz2mctu/nB0MQ4IP1kGrGoUkir2GPVzY5Ckhz/ZkKXervTXy8klHtbNUJj/ax6lYhMI7A4=
+trusted comment: timestamp:1593609508	file:parental-control.md
+TzaQTIxb5gIPPC2lsTgyyduQ+F45bi/0U7ZItaXkkTe6jhAArA7LN/Pk2YGjsyk2Ix1vExjmLTOoUQdFu6y5Bw==

--- a/v3/public-resolvers.md
+++ b/v3/public-resolvers.md
@@ -16,7 +16,7 @@ To use that list, add this to the `[sources]` section of your
 `dnscrypt-proxy.toml` configuration file:
 
     [sources.'public-resolvers']
-    urls = ['https://raw.githubusercontent.com/DNSCrypt/dnscrypt-resolvers/master/v2/public-resolvers.md', 'https://download.dnscrypt.info/resolvers-list/v2/public-resolvers.md']
+    urls = ['https://raw.githubusercontent.com/DNSCrypt/dnscrypt-resolvers/master/v3/public-resolvers.md', 'https://download.dnscrypt.info/resolvers-list/v3/public-resolvers.md']
     minisign_key = 'RWQf6LRCGA9i53mlYecO4IzT51TGPpvWucNSCh1CBM0QTaLn73Y7GFO3'
     cache_file = 'public-resolvers.md'
 

--- a/v3/public-resolvers.md
+++ b/v3/public-resolvers.md
@@ -171,7 +171,7 @@ sdns://AgAAAAAAAAAACTIyMy41LjUuNSCoF6cUD2dwqtorNi96I2e3nkHPSJH1ka3xbdOglmOVkQ5kb
 ## ams-dnscrypt-nl
 
 Resolver in Amsterdam. DNSCrypt protocol. Non-logging, non-filtering, DNSSEC.
-Forward DNS to anoymized DNS servers.
+Forward DNS to anonymized DNS servers.
 
 sdns://AQcAAAAAAAAAEjUxLjE1LjEyNC4yMDg6NDM0MyC8E4j1dj497HXxyQ_JFb-2iurf6xxF9phRgGOcYOfxYh8yLmRuc2NyeXB0LWNlcnQuYW1zLWRuc2NyeXB0LW5s
 
@@ -179,7 +179,7 @@ sdns://AQcAAAAAAAAAEjUxLjE1LjEyNC4yMDg6NDM0MyC8E4j1dj497HXxyQ_JFb-2iurf6xxF9phRg
 ## ams-doh-nl
 
 Resolver in Amsterdam. DoH protocol. Non-logging, non-filtering, DNSSEC.
-Forward DNS to anoymized DNS servers.
+Forward DNS to anonymized DNS servers.
 
 sdns://AgcAAAAAAAAAETUxLjE1LjEyNC4yMDg6NDQzABZkbnNubC5hbGVrYmVyZy5uZXQ6NDQzCi9kbnMtcXVlcnk
 
@@ -226,6 +226,20 @@ DNS-over-HTTPS / DNS over TLS server with PiHole. Filters ads, trackers and malw
 Hosted in Nuremberg, Germany. (https://dns.brahma.world)
 
 sdns://AgMAAAAAAAAADjk0LjEzMC4yMjQuMTE0ID4aGg9sU_PpekktVwhLW5gHBZ7gV6sVBYdv2D_aPbg4EGRucy5icmFobWEud29ybGQKL2Rucy1xdWVyeQ
+
+
+## bcn-dnscrypt
+
+Resolver in Barcelona, Spain. DNSCrypt protocol. Non-logging, non-filtering, DNSSEC. Anonymized.
+
+sdns://AQcAAAAAAAAAEjUxLjE1LjEyNC4yMDg6NDM0MyC8E4j1dj497HXxyQ_JFb-2iurf6xxF9phRgGOcYOfxYh8yLmRuc2NyeXB0LWNlcnQuYW1zLWRuc2NyeXB0LW5s
+
+
+## bcn-doh
+
+Resolver in Barcelona, Spain. DoH protocol. Non-logging, non-filtering, DNSSEC. Anonymized.
+
+sdns://AgcAAAAAAAAAETUxLjE1LjEyNC4yMDg6NDQzABZkbnNubC5hbGVrYmVyZy5uZXQ6NDQzCi9kbnMtcXVlcnk
 
 
 ## brahma-world-ipv6
@@ -1864,14 +1878,14 @@ sdns://AQcAAAAAAAAAFDE3OC4yMTYuMjAxLjIyMjoyMDUzICXE4YgpFUaXj5wrvbanr6QB7aBRBQhdU
 
 ## sth-dnscrypt-se
 
-Resolver in Stockholm, Sweden. DNSCrypt server. Non-logging, non-filtering, DNSSEC. Forward DNS to anoymized DNS servers
+Resolver in Stockholm, Sweden. DNSCrypt server. Non-logging, non-filtering, DNSSEC. Forward DNS to anonymized DNS servers
 
 sdns://AQcAAAAAAAAAETQ1LjE1My4xODcuOTY6NDQzILwTiPV2Pj3sdfHJD8kVv7aK6t_rHEX2mFGAY5xg5_FiHzIuZG5zY3J5cHQtY2VydC5zdGgtZG5zY3J5cHQtc2U
 
 
 ## sth-doh-se
 
-Resolver in Stockholm, Sweden. DoH server. Non-logging, non-filtering, DNSSEC. Forward DNS to anoymized DNS servers
+Resolver in Stockholm, Sweden. DoH server. Non-logging, non-filtering, DNSSEC. Forward DNS to anonymized DNS servers
 
 sdns://AgcAAAAAAAAAETQ1LjE1My4xODcuOTY6NDQzABZkbnNzZS5hbGVrYmVyZy5uZXQ6NDQzBC9kbnM
 

--- a/v3/public-resolvers.md.minisig
+++ b/v3/public-resolvers.md.minisig
@@ -1,4 +1,4 @@
 untrusted comment: signature from minisign secret key
-RWQf6LRCGA9i55f2h/ihvufmxthuYUDJRymqVgKBl+REuHgQQ80cjAWrMIVWV5r4Mw4c7aq12IMIDOhht3TxZml+9AQRUeUIpAk=
-trusted comment: timestamp:1593498378	file:public-resolvers.md
-uEZ5kR58whktKGANrk8vsURnaf6p9eW58RupawbcdrJcSt+/VjyQIXuq+fsOi3uumcMhtT0R9zz5cq/vZ0H1BA==
+RWQf6LRCGA9i5xE5vsLnDubLnivVAlUZ+oNOW1HFt/adJbGEft2GWMvGN9yFRP0oKCdHN1WMI/OY2dZ9EM5in/1S8IlMo2wDWwE=
+trusted comment: timestamp:1593609508	file:public-resolvers.md
+LkDKxWEEr2zpumBkAXUHzieCBD6yiBOiqErN+YsDXaYMphMaze3C/QZMd5GQPpiVmzXpEukQVJiBK2FaZSy0BA==


### PR DESCRIPTION
Added new resolvers and fixed typo.

## bcn-dnscrypt

Resolver in Barcelona, Spain. DNSCrypt protocol. Non-logging, non-filtering, DNSSEC.

sdns://AQcAAAAAAAAAEjUxLjE1LjEyNC4yMDg6NDM0MyC8E4j1dj497HXxyQ_JFb-2iurf6xxF9phRgGOcYOfxYh8yLmRuc2NyeXB0LWNlcnQuYW1zLWRuc2NyeXB0LW5s


## bcn-doh

Resolver in Barcelona, Spain. DoH protocol. Non-logging, non-filtering, DNSSEC.

sdns://AgcAAAAAAAAAETUxLjE1LjEyNC4yMDg6NDQzABZkbnNubC5hbGVrYmVyZy5uZXQ6NDQzCi9kbnMtcXVlcnk