### PR TITLE
Update dnscrypt uk

### DIFF
--- a/v2/relays.md
+++ b/v2/relays.md
@@ -292,3 +292,31 @@ sdns://gRA2NC4xMjAuNS4yNTE6NDQz
 Anonymized DNS relay hosted in US - Las Vegas, NV provided by https://cryptostorm.is/
 
 sdns://gRAzNy4xMjAuMTQ3LjI6NDQz
+
+
+## anon-dnscrypt.uk-ipv4
+
+Anonymized DNS relay hosted in UK on DigitalOcean
+
+sdns://gRIxMzkuNTkuMjAwLjExNjo0NDM
+
+
+## anon-dnscrypt.uk-ipv6
+
+Anonymized DNS relay hosted in UK on DigitalOcean
+
+sdns://gR5bMmEwMzpiMGMwOjE6ZTA6OjJlMzplMDAxXTo0NDM
+
+
+## anon-v.dnscrypt.uk-ipv4
+
+Anonymized DNS relay hosted in UK on Vultr
+
+sdns://gRMxMDQuMjM4LjE4Ni4xOTI6NDQz
+
+
+## anon-v.dnscrypt.uk-ipv6
+
+Anonymized DNS relay hosted in UK on Vultr
+
+sdns://gSxbMjAwMToxOWYwOjc0MDI6MTU3NDo1NDAwOjJmZjpmZTY2OjJjZmZdOjQ0Mw

--- a/v3/public-resolvers.md
+++ b/v3/public-resolvers.md
@@ -892,18 +892,18 @@ sdns://AQcAAAAAAAAAEjE0NC45MS4xMDYuMjI3OjQ0MyBdoGNCA_IFO3Mx7f02CSF8RLhU8bAqxq52h
 
 ## dnscrypt.uk-ipv4
 
-DNSCrypt v2, no logs, uncensored, DNSSEC. Hosted in London UK on Digital Ocean
+DNSCrypt, no logs, uncensored, DNSSEC. Hosted in London UK on Digital Ocean
 https://www.dnscrypt.uk
 
-sdns://AQcAAAAAAAAAEjEzOS41OS4yMDAuMTE2OjQ0MyBxkKwJmxhDAMvj-aF2TcFOK16cSI5EpMxBJG3Ze0lRvBsyLmRuc2NyeXB0LWNlcnQuZG5zY3J5cHQudWs
+sdns://AQcAAAAAAAAAETE2NS4yMzIuMzIuOTU6NDQzIAHTDugOIE3aGHHToQ8oUVRnZb8UtNpEBKT_BG19qWg8GzIuZG5zY3J5cHQtY2VydC5kbnNjcnlwdC51aw
 
 
 ## dnscrypt.uk-ipv6
 
-DNSCrypt v2, no logs, uncensored, DNSSEC. Hosted in London UK on Digital Ocean
+DNSCrypt, no logs, uncensored, DNSSEC. Hosted in London UK on Digital Ocean
 https://www.dnscrypt.uk
 
-sdns://AQcAAAAAAAAAHlsyYTAzOmIwYzA6MTplMDo6MmUzOmUwMDFdOjQ0MyBxkKwJmxhDAMvj-aF2TcFOK16cSI5EpMxBJG3Ze0lRvBsyLmRuc2NyeXB0LWNlcnQuZG5zY3J5cHQudWs
+sdns://AQcAAAAAAAAAHlsyYTAzOmIwYzA6MTplMDo6NDg3OjEwMDFdOjQ0MyAB0w7oDiBN2hhx06EPKFFUZ2W_FLTaRASk_wRtfaloPBsyLmRuc2NyeXB0LWNlcnQuZG5zY3J5cHQudWs
 
 
 ## dnsforfamily

--- a/v3/relays.md
+++ b/v3/relays.md
@@ -163,14 +163,14 @@ sdns://gRIxNDQuOTEuMTA2LjIyNzo0NDM
 
 Anonymized DNS relay hosted in UK on DigitalOcean
 
-sdns://gRIxMzkuNTkuMjAwLjExNjo0NDM
+sdns://gRExNjUuMjMyLjMyLjk1OjQ0Mw
 
 
 ## anon-dnscrypt.uk-ipv6
 
 Anonymized DNS relay hosted in UK on DigitalOcean
 
-sdns://gR5bMmEwMzpiMGMwOjE6ZTA6OjJlMzplMDAxXTo0NDM
+sdns://gR5bMmEwMzpiMGMwOjE6ZTA6OjQ4NzoxMDAxXTo0NDM
 
 
 ## anon-ev-to


### PR DESCRIPTION
New host for dnscrypt.uk-ipv{4|6}   and the anon relays.
I'll let requests roll off the old server onto the new one before shutting it down.