### PR TITLE
Add the upcoming dnscrypt.pl as a successor to soltysiak

### DIFF
--- a/v3/public-resolvers.md
+++ b/v3/public-resolvers.md
@@ -867,7 +867,7 @@ sdns://AQcAAAAAAAAAETE2MS45Ny4xMDEuNTE6NDQzIAoyujLMUVbenTQcjXIJnLrRr3Vu9cmmFZ1JU
 
 Free | No filtering | Zero logs | DNSSEC | Poland | https://dnscrypt.pl/ | @dnscryptpl
 
-sdns://AQcAAAAAAAAAEzE3OC4yMTYuMjAxLjEyODo0NDMgf2F8uB6lU9I0xJvCecdPe1SYBQ0dvxEa_uaZY8ZHoWkbMi5kbnNjcnlwdC1jZXJ0LmRuc2NyeXB0LnBs
+sdns://AQcAAAAAAAAAFDE3OC4yMTYuMjAxLjEyODoyMDUzIH9hfLgepVPSNMSbwnnHT3tUmAUNHb8RGv7mmWPGR6FpGzIuZG5zY3J5cHQtY2VydC5kbnNjcnlwdC5wbA
 
 
 ## dnscrypt.uk-ipv4

--- a/v3/public-resolvers.md
+++ b/v3/public-resolvers.md
@@ -863,6 +863,13 @@ Non-logging, non-censoring, DNSSEC-capable DNSCrypt resolver hosted in Germany (
 sdns://AQcAAAAAAAAAETE2MS45Ny4xMDEuNTE6NDQzIAoyujLMUVbenTQcjXIJnLrRr3Vu9cmmFZ1JUTOAzeoeHDIuZG5zY3J5cHQtY2VydC5kbnNjcnlwdC5vbmU
 
 
+## dnscrypt.pl
+
+Free | No filtering | Zero logs | DNSSEC | Poland | https://dnscrypt.pl/ | @dnscryptpl
+
+sdns://AQcAAAAAAAAAEzE3OC4yMTYuMjAxLjEyODo0NDMgf2F8uB6lU9I0xJvCecdPe1SYBQ0dvxEa_uaZY8ZHoWkbMi5kbnNjcnlwdC1jZXJ0LmRuc2NyeXB0LnBs
+
+
 ## dnscrypt.uk-ipv4
 
 DNSCrypt, no logs, uncensored, DNSSEC. Hosted in London UK on Digital Ocean


### PR DESCRIPTION
After 7 years it's time to setup dnscrypt.pl on new infrastructure, cleaner setup, up2date software ... with a proper name.
I'm setting up this service and in near future I'm planning to:
- add 2nd 'anti-malware' service,
- add ipv6 variants for both.

A bit later:
- mark `soltysiak` as legacy and to be gradually retired,
- and when times comes remove it.
