### PR TITLE
Add dnscrypt.pl-guardian

### DIFF
--- a/v3/public-resolvers.md
+++ b/v3/public-resolvers.md
@@ -935,6 +935,13 @@ Free | No filtering | Zero logs | DNSSEC | Poland | https://dnscrypt.pl/ | @dnsc
 sdns://AQcAAAAAAAAAFDE3OC4yMTYuMjAxLjEyODoyMDUzIH9hfLgepVPSNMSbwnnHT3tUmAUNHb8RGv7mmWPGR6FpGzIuZG5zY3J5cHQtY2VydC5kbnNjcnlwdC5wbA
 
 
+## dnscrypt.pl-guardian
+
+Free | Malware and phishing filtering | Zero logs | DNSSEC | Poland | https://dnscrypt.pl/ | @dnscryptpl
+
+sdns://AQMAAAAAAAAAFDE3OC4yMTYuMjAxLjEyODoyMDU0IH9hfLgepVPSNMSbwnnHT3tUmAUNHb8RGv7mmWPGR6FpGzIuZG5zY3J5cHQtY2VydC5kbnNjcnlwdC5wbA
+
+
 ## dnscrypt.uk-ipv4
 
 DNSCrypt, no logs, uncensored, DNSSEC. Hosted in London UK on Digital Ocean


### PR DESCRIPTION
So aside to the vanilla dnscrypt.pl I'm about to launch a filtered service called guardian :-)
It's on the same box and same ip, but port +1.

Would that mean it'd be good to update encrypted-dns.toml to include this port?

allowed_ports = [ 443, 553, 853, 1443, 2053, 4343, 4434, 4443, 5353, 5443, 8443, 15353 ]
