### PR TITLE
add doh.linuxsec.org to public resolvers

### DIFF
--- a/v3/public-resolvers.md
+++ b/v3/public-resolvers.md
@@ -2112,3 +2112,19 @@ DNSSEC/unfiltered/non-logged. Hosted on Vultr in Chicago, IL. Running the offici
 
 sdns://AQcAAAAAAAAALFsyMDAxOjE5ZjA6NWMwMToxNDdlOjU0MDA6M2ZmOmZlMmE6M2IxZl06NDQzIEzTIwoduzgzHk_81A0eMlfy_Ylp6l08sjLsi3gEFtHnHjIuZG5zY3J5cHQtY2VydC56YWNrcHRnNS11cy1pbA
 
+## linuxsec-doh
+
+Non-logging DoH server in the Indonesia operated by LinuxSec.
+Report any issues to rin@linuxsec.org
+
+https://doh.linuxsec.org
+
+sdns://AgcAAAAAAAAADDEwMy44NS4xNS42MCAyhv9lpl-vMghe6hOIw3OLp-N4c8kGzOPEootMwqWJiBBkb2gubGludXhzZWMub3JnCi9kbnMtcXVlcnk
+
+## linuxsec-adguard
+
+Non-logging DoH with malware and ad blocker. Resolver located in the Indonesia. Operated by LinuxSec. 
+
+https://doh.linuxsec.org
+
+sdns://AgcAAAAAAAAADDEwMy44NS4xNS42MCAyhv9lpl-vMghe6hOIw3OLp-N4c8kGzOPEootMwqWJiBBkb2gubGludXhzZWMub3JnCC9hZGd1YXJk


### PR DESCRIPTION
doh servers for linuxsec.org. Located in Indonesia.