### PR TITLE
Added Mullvad resolvers

### DIFF
--- a/v3/public-resolvers.md
+++ b/v3/public-resolvers.md
@@ -1741,6 +1741,42 @@ Public | Non-filtering | Non-logging | DNSSEC aware | Hosted in UK | Operated by
 sdns://AQcAAAAAAAAADjUxLjE5NS4yMDAuMTgyIOdFe4OLrR_kCKC-8omGs5my5qxIyBgkldWZoSUmYvCNHTIuZG5zY3J5cHQtY2VydC5tb3VsdGljYXN0LXVr
 
 
+## mullvad-doh
+
+Public non-filtering, non-logging (audited), DNSSEC-capable, DNS-over-HTTPS resolver hosted by VPN provider Mullvad
+Anycast IPv4/IPv6 with servers in SE, DE, UK, US, AU and SG
+https://mullvad.net/en/help/dns-over-https-and-dns-over-tls/
+
+sdns://AgcAAAAAAAAAACCXOkEnb_0B4CeiqtSeNMN4RtPpdv9qYgtnEuM4MgQapg9kb2gubXVsbHZhZC5uZXQKL2Rucy1xdWVyeQ
+
+
+## mullvad-dot
+
+Public non-filtering, non-logging (audited), DNSSEC-capable, DNS-over-TLS resolver hosted by VPN provider Mullvad
+Anycast IPv4/IPv6 with servers in SE, DE, UK, US, AU and SG
+https://mullvad.net/en/help/dns-over-https-and-dns-over-tls/
+
+sdns://AwcAAAAAAAAAACCXOkEnb_0B4CeiqtSeNMN4RtPpdv9qYgtnEuM4MgQapg9kb2gubXVsbHZhZC5uZXQ
+
+
+## mullvad-adblock-doh
+
+Public ad-blocking, non-logging (audited), DNSSEC-capable, DNS-over-HTTPS resolver hosted by VPN provider Mullvad
+Anycast IPv4/IPv6 with servers in SE, DE, UK, US, AU and SG
+https://mullvad.net/en/help/dns-over-https-and-dns-over-tls/
+
+sdns://AgMAAAAAAAAAACCXOkEnb_0B4CeiqtSeNMN4RtPpdv9qYgtnEuM4MgQaphdhZGJsb2NrLmRvaC5tdWxsdmFkLm5ldAovZG5zLXF1ZXJ5
+
+
+## mullvad-adblock-dot
+
+Public ad-blocking, non-logging (audited), DNSSEC-capable, DNS-over-TLS resolver hosted by VPN provider Mullvad
+Anycast IPv4/IPv6 with servers in SE, DE, UK, US, AU and SG
+https://mullvad.net/en/help/dns-over-https-and-dns-over-tls/
+
+sdns://AwMAAAAAAAAAACCXOkEnb_0B4CeiqtSeNMN4RtPpdv9qYgtnEuM4MgQaphdhZGJsb2NrLmRvaC5tdWxsdmFkLm5ldA
+
+
 ## nextdns
 
 NextDNS is a cloud-based private DNS service that gives you full control

--- a/v3/public-resolvers.md
+++ b/v3/public-resolvers.md
@@ -1747,16 +1747,7 @@ Public non-filtering, non-logging (audited), DNSSEC-capable, DNS-over-HTTPS reso
 Anycast IPv4/IPv6 with servers in SE, DE, UK, US, AU and SG
 https://mullvad.net/en/help/dns-over-https-and-dns-over-tls/
 
-sdns://AgcAAAAAAAAAACCXOkEnb_0B4CeiqtSeNMN4RtPpdv9qYgtnEuM4MgQapg9kb2gubXVsbHZhZC5uZXQKL2Rucy1xdWVyeQ
-
-
-## mullvad-dot
-
-Public non-filtering, non-logging (audited), DNSSEC-capable, DNS-over-TLS resolver hosted by VPN provider Mullvad
-Anycast IPv4/IPv6 with servers in SE, DE, UK, US, AU and SG
-https://mullvad.net/en/help/dns-over-https-and-dns-over-tls/
-
-sdns://AwcAAAAAAAAAACCXOkEnb_0B4CeiqtSeNMN4RtPpdv9qYgtnEuM4MgQapg9kb2gubXVsbHZhZC5uZXQ
+sdns://AgcAAAAAAAAAACD5_zfwLmMstzhwJcB-V5CKPTcbfJXYzdA5DeIx7ZQ6Eg9kb2gubXVsbHZhZC5uZXQKL2Rucy1xdWVyeQ
 
 
 ## mullvad-adblock-doh
@@ -1765,16 +1756,7 @@ Public ad-blocking, non-logging (audited), DNSSEC-capable, DNS-over-HTTPS resolv
 Anycast IPv4/IPv6 with servers in SE, DE, UK, US, AU and SG
 https://mullvad.net/en/help/dns-over-https-and-dns-over-tls/
 
-sdns://AgMAAAAAAAAAACCXOkEnb_0B4CeiqtSeNMN4RtPpdv9qYgtnEuM4MgQaphdhZGJsb2NrLmRvaC5tdWxsdmFkLm5ldAovZG5zLXF1ZXJ5
-
-
-## mullvad-adblock-dot
-
-Public ad-blocking, non-logging (audited), DNSSEC-capable, DNS-over-TLS resolver hosted by VPN provider Mullvad
-Anycast IPv4/IPv6 with servers in SE, DE, UK, US, AU and SG
-https://mullvad.net/en/help/dns-over-https-and-dns-over-tls/
-
-sdns://AwMAAAAAAAAAACCXOkEnb_0B4CeiqtSeNMN4RtPpdv9qYgtnEuM4MgQaphdhZGJsb2NrLmRvaC5tdWxsdmFkLm5ldA
+sdns://AgMAAAAAAAAAACD5_zfwLmMstzhwJcB-V5CKPTcbfJXYzdA5DeIx7ZQ6EhdhZGJsb2NrLmRvaC5tdWxsdmFkLm5ldAovZG5zLXF1ZXJ5
 
 
 ## nextdns


### PR DESCRIPTION
Added entries for Mullvad's resolvers, as requested in #453

Note that:

* This is untested
* This is my first go at generating stamps, based on https://dnscrypt.info/stamps/
* Only hostname is used, not addr
* The SHA256 is the fingerprint of the "Go Daddy Secure Certificate Authority - G2" intermediate currently used to issue the leaf cert(s)
* The stamps do not include bootstrap_ipi, despite these being recommended by https://github.com/jedisct1/doh-server#operational-recommendations, since the online generator didn't seem to support it
* I've made no attempts at updating minisig after my changes
* Mullvad declined to provide a description of their service, so the tagline should merely be considered a suggestion