### PR TITLE
Add new server Altername

### DIFF
--- a/v3/public-resolvers.md
+++ b/v3/public-resolvers.md
@@ -182,6 +182,12 @@ Homepage: https://alidns.com/
 
 sdns://AgAAAAAAAAAACTIyMy41LjUuNSCoF6cUD2dwqtorNi96I2e3nkHPSJH1ka3xbdOglmOVkQ5kbnMuYWxpZG5zLmNvbQovZG5zLXF1ZXJ5
 
+## altername
+
+Protocol: DNSCrypt IPv4 | Features: Non-logging, Non-filtering, DNSSEC, OpenNIC, EmerDNS | Current status: Beta | Location: Moscow, Russia
+
+sdns://AQcAAAAAAAAAEzk1LjE4MS4xNTUuMTQwOjg0NDMgvZmXVeT0DhM8O1F9vIC-0KIjH11eoON1lQxZKczVYxIZMi5kbnNjcnlwdC1jZXJ0LmFsdGVybmFtZQ
+
 
 ## ams-ads-doh-nl
 


### PR DESCRIPTION
IPv4-only non-filtering and non-logging DNSCrypt-server with support EmerDNS and OpenNIC. Located  in Moscow, Russia.
Having Beta status due stability testing.