### PR TITLE
Add openinternet.io ODoH target and DoH resolvers

### DIFF
--- a/v3/odoh-servers.md
+++ b/v3/odoh-servers.md
@@ -59,6 +59,15 @@ Maintained by @kokial
 
 sdns://BQcAAAAAAAAAGG9kb2gtdGFyZ2V0LmFsZWtiZXJnLm5ldAovZG5zLXF1ZXJ5
 
+## odoh-resolver4.dns.openinternet.io
+
+ODoH target server. no logs, no filter, DNSSEC.
+Running on dedicated hardware colocated at Sonic.net in Santa Rosa, CA in the United States.
+
+Uses Sonic's recusrive DNS servers as upstream resolvers (but is not affiliated with Sonic
+in any way). Provided by https://openinternet.io
+
+sdns://BQcAAAAAAAAAHXJlc29sdmVyNC5kbnMub3BlbmludGVybmV0LmlvCi9kbnMtcXVlcnk
 
 ## odoh-tiarap.org
 

--- a/v3/public-resolvers.md
+++ b/v3/public-resolvers.md
@@ -2099,14 +2099,13 @@ sdns://AQcAAAAAAAAAGVsyYTAwOjZkNDc6MTA6YmE5OjoxXTo0NDMg-XLL8GqKxf3VAytOvDoIg06-q
 
 ## resolver4.dns.openinternet.io
 
-DNSCrypt resolver on dedicated hardware, colocated at Sonic.net in Santa Rosa, CA in the United States.
+DNSCrypt & DoH resolver on dedicated hardware colocated at Sonic.net in Santa Rosa, CA in the United States.
 
 No log, no filter, DNSSEC. Uses Sonic's recusrive DNS servers as upstream resolvers (but is not affiliated with Sonic
-in any way).
-
-Provided by https://openinternet.io
+in any way). Provided by https://openinternet.io
 
 sdns://AQcAAAAAAAAADTcwLjM2LjE3MC4xMjYgIMqRyWkPSPlDAmN_2ne3A6A6EQtQRyEJcXoCWPHbX5EtMi5kbnNjcnlwdC1jZXJ0LnJlc29sdmVyNC5kbnMub3BlbmludGVybmV0Lmlv
+sdns://AgcAAAAAAAAADTcwLjM2LjE3MC4xMjYAHXJlc29sdmVyNC5kbnMub3BlbmludGVybmV0LmlvCi9kbnMtcXVlcnk
 
 
 ## safesurfer


### PR DESCRIPTION
Thanks to doh-proxy, resolver4.dns.openinternet.io now supports DoH in addition to DNSCrypt and works as an ODoH target.