### PR TITLE
Return of curzon-[vie,prg], add curzon-lux

### DIFF
--- a/v3/relays.md
+++ b/v3/relays.md
@@ -47,6 +47,27 @@ Anonymized DNS relay hosted in Barcelona, Spain.
 sdns://gRMxODUuMjUzLjE1NC42Njo0MzQz
 
 
+## anon-curzon-lux
+
+Anonymized DNS relay hosted in Roost, Luxembourg on BuyVM - maintained by @ztheory. No log.
+
+sdns://gRExMDQuMjQ0LjcyLjYxOjQ0Mw
+
+
+## anon-curzon-prg
+
+Anonymized DNS relay hosted in Prague, Czech Republic on SkylonHost - maintained by @ztheory. No log.
+
+sdns://gRIxMDkuMjQ4LjQzLjE1NDo0NDM
+
+
+## anon-curzon-vie
+
+Anonymized DNS relay hosted in Vienna, Austria on VPS247 - maintained by @ztheory. No log.
+
+sdns://gRAxODUuOS4xOS4xMzc6NDQz
+
+
 ## anon-dnscrypt.uk-ipv4
 
 Anonymized DNS relay hosted in UK on DigitalOcean


### PR DESCRIPTION
After running into https://github.com/DNSCrypt/encrypted-dns-server/issues/76 and disabling `daemonize` , these relays ran for ~6 days without the error, so I think they should be here to stay this time.