### PR TITLE
opennic-R4SAS: update doh pinned certificates

### DIFF
--- a/v3/opennic.md
+++ b/v3/opennic.md
@@ -37,7 +37,7 @@ DOH • DNSSEC • OpenNIC • Non-logging • Uncensored - hosted on OVH - http
 Location: Paris, France
 Maintained by R4SAS - https://github.com/r4sas
 
-sdns://AgcAAAAAAAAADTE1MS44MC4yMjIuNzkgKVTnuGY0K1Ihqu1Pba8r5vOERK-LffNTJu1qlyaQv3gQb3Blbm5pYy5pMnBkLnh5egovZG5zLXF1ZXJ5
+sdns://AgYAAAAAAAAADTE1MS44MC4yMjIuNzkgI_Tezy3E7gfCD1gW5aEuZxyjXKJ_LGgj6nrv42n4y7IQb3Blbm5pYy5pMnBkLnh5egovZG5zLXF1ZXJ5
 
 
 ## opennic-R4SAS-doh-ipv6
@@ -46,7 +46,7 @@ DOH • DNSSEC • OpenNIC • Non-logging • Uncensored - hosted on OVH - http
 Location: Paris, France
 Maintained by R4SAS - https://github.com/r4sas
 
-sdns://AgcAAAAAAAAAF1syMDAxOjQ3MDoxZjE1OmI4MDo6NTNdIClU57hmNCtSIartT22vK-bzhESvi33zUybtapcmkL94EG9wZW5uaWMuaTJwZC54eXoKL2Rucy1xdWVyeQ
+sdns://AgYAAAAAAAAAF1syMDAxOjQ3MDoxZjE1OmI4MDo6NTNdICP03s8txO4Hwg9YFuWhLmcco1yifyxoI-p67-Np-MuyEG9wZW5uaWMuaTJwZC54eXoKL2Rucy1xdWVyeQ
 
 
 ## opennic-R4SAS-ipv6

--- a/v3/public-resolvers.md
+++ b/v3/public-resolvers.md
@@ -1694,8 +1694,25 @@ DOH • DNSSEC • OpenNIC • Non-logging • Uncensored - hosted on OVH - http
 Location: Paris, France
 Maintained by R4SAS - https://github.com/r4sas
 
-sdns://AgcAAAAAAAAADTE1MS44MC4yMjIuNzkgKVTnuGY0K1Ihqu1Pba8r5vOERK-LffNTJu1qlyaQv3gQb3Blbm5pYy5pMnBkLnh5egovZG5zLXF1ZXJ5
+sdns://AgYAAAAAAAAADTE1MS44MC4yMjIuNzkgI_Tezy3E7gfCD1gW5aEuZxyjXKJ_LGgj6nrv42n4y7IQb3Blbm5pYy5pMnBkLnh5egovZG5zLXF1ZXJ5
 
+
+## opennic-R4SAS-doh-ipv6
+
+DOH • DNSSEC • OpenNIC • Non-logging • Uncensored - hosted on OVH - https://opennic.i2pd.xyz/
+Location: Paris, France
+Maintained by R4SAS - https://github.com/r4sas
+
+sdns://AgYAAAAAAAAAF1syMDAxOjQ3MDoxZjE1OmI4MDo6NTNdICP03s8txO4Hwg9YFuWhLmcco1yifyxoI-p67-Np-MuyEG9wZW5uaWMuaTJwZC54eXoKL2Rucy1xdWVyeQ
+
+
+## opennic-R4SAS-ipv6
+
+DNSSEC • OpenNIC • Non-logging • Uncensored - hosted on OVH - https://opennic.i2pd.xyz/
+Location: Paris, France
+Maintained by R4SAS - https://github.com/r4sas
+
+sdns://AQcAAAAAAAAAF1syMDAxOjQ3MDoxZjE1OmI4MDo6NTNdIKnWMjpPJYAJJhl1FQLOIx4fdtned2yHxruyig7_2w5OIDIuZG5zY3J5cHQtY2VydC5vcGVubmljLmkycGQueHl6
 
 ## opennic-luggs
 

--- a/v3/relays.md
+++ b/v3/relays.md
@@ -118,6 +118,13 @@ Anonymized DNS relay hosted in OVH, Paris, France - maintained by R4SAS - https:
 sdns://gQ0xNTEuODAuMjIyLjc5
 
 
+## anon-opennic-R4SAS-ipv6
+
+Anonymized DNS relay hosted in OVH, Paris, France - maintained by R4SAS - https://github.com/r4sas
+
+sdns://gRtbMjAwMTo0NzA6MWYxNTpiODA6OjUzXTo0NDM
+
+
 ## anon-pf
 
 Anonymized DNS relay by post-factum | Zürich, Switzerland | https://dns.post-factum.tk


### PR DESCRIPTION
Updating outdated pinned certificates hashes.
And once again: @jedisct1, please add IPv6 records even if your provider can't reach HE.net network. If you can't access it, that not means that nobody can do that.