### PR TITLE
Add `ahadns-doh-ny`/`ahadns-doh-ny-ipv6` in `v3/public-resolvers.md`

### DIFF
--- a/v3/public-resolvers.md
+++ b/v3/public-resolvers.md
@@ -172,6 +172,22 @@ Server statistics can be seen at: https://statistics.ahadns.com/?server=nl
 sdns://AgMAAAAAAAAAFlsyYTA0OjUyYzA6MTAxOjc1Ojo3NV2gzBBg05yDKbYrb7x9DW35MJhpuYHn5jktXNj6QI9NgOYgRE69Z7uD-IB7OSHpOKyReLiCvVCq2xEjHwRM9fCN984RZG9oLm5sLmFoYWRucy5uZXQKL2Rucy1xdWVyeQ
 
 
+## ahadns-doh-ny
+
+A zero logging DNS with support for DNS-over-HTTPS (DoH) & DNS-over-TLS (DoT). Blocks ads, malware, trackers, viruses, ransomware, telemetry and more. No persistent logs. DNSSEC. Hosted in New York. By https://ahadns.com/
+Server statistics can be seen at: https://statistics.ahadns.com/?server=ny
+
+sdns://AgMAAAAAAAAADjE4NS4yMTMuMjYuMTg3oMwQYNOcgym2K2-8fQ1t-TCYabmB5-Y5LVzY-kCPTYDmIEROvWe7g_iAezkh6TiskXi4gr1QqtsRIx8ETPXwjffOEWRvaC5ueS5haGFkbnMubmV0Ci9kbnMtcXVlcnk
+
+
+## ahadns-doh-ny-ipv6
+
+A zero logging DNS with support for DNS-over-HTTPS (DoH) & DNS-over-TLS (DoT). Blocks ads, malware, trackers, viruses, ransomware, telemetry and more. No persistent logs. DNSSEC. Hosted in New York. By https://ahadns.com/
+Server statistics can be seen at: https://statistics.ahadns.com/?server=ny
+
+sdns://AgMAAAAAAAAAE1syYTBkOjU2MDA6MzM6Mzo6M12gzBBg05yDKbYrb7x9DW35MJhpuYHn5jktXNj6QI9NgOYgRE69Z7uD-IB7OSHpOKyReLiCvVCq2xEjHwRM9fCN984RZG9oLm55LmFoYWRucy5uZXQKL2Rucy1xdWVyeQ
+
+
 ## alidns-doh
 
 A public DNS resolver that supports DoH/DoT in mainland China, provided by Alibaba-Cloud.


### PR DESCRIPTION
This is my first PR to add a public resolver here, so I just simply add only one server with both IPv4 & IPv6 stamp.

BTW, I initially found that the dns stamp I generated is much shorted than those in the markdown files, so I decoded other ahadns stamps and found that they're using both Let's Encrypt R3 & Let's Encrypt E1 cert hashes, so I did the same for the consistent, but 
I'm not sure if it's correct, as I only saw the Let's Encrypt R3 cert.

cc #601