### PR TITLE
[wip] add dnscrypt.dotya.ml servers

### DIFF
--- a/v3/public-resolvers.md
+++ b/v3/public-resolvers.md
@@ -1210,6 +1210,15 @@ Free, Canadian, uncensored, no-logs, encrypted, and DNSSEC validated DNS service
 
 sdns://AQcAAAAAAAAAJVsyNjA3OjUzMDA6NjE6OTVmOjcyODM6MTFkOTpmODY6ZTY5MF0gmHxwqJfb2hUaNK1LVeqADvVhzASq1cV90sPYYfwX9CkiMi5kbnNjcnlwdC1jZXJ0LmRuc2NyeXB0LmNhLTItaXB2Ng
 
+## dnscrypt.dotya.ml
+Free, uncensored, DNSSEC-validated, non-logging DNSCrypt server hosted in Nuremberg, Germany
+on Contabo servers, operated by dotya.ml, configs live [here](https://git.dotya.ml/dotya.ml/dnscrypt-server). Available over both IPv4 and IPv6.
+
+### IPv4
+sdns://AQcAAAAAAAAAETE0NC45MS43MC42Mjo1NDQzIHF-JiN46cNwFXJleEVWGWgrhe2QeysUtZoo9HwzYCMzITIuZG5zY3J5cHQtY2VydC5kbnNjcnlwdC5kb3R5YS5tbA
+
+### IPv6
+sdns://AQcAAAAAAAAAHFsyYTAyOmMyMDc6MjAzMDozOTY6OjFdOjU0NDMgcX4mI3jpw3AVcmV4RVYZaCuF7ZB7KxS1mij0fDNgIzMhMi5kbnNjcnlwdC1jZXJ0LmRuc2NyeXB0LmRvdHlhLm1s
 
 ## dnscrypt.eu-nl
 

--- a/v3/public-resolvers.md
+++ b/v3/public-resolvers.md
@@ -1210,14 +1210,24 @@ Free, Canadian, uncensored, no-logs, encrypted, and DNSSEC validated DNS service
 
 sdns://AQcAAAAAAAAAJVsyNjA3OjUzMDA6NjE6OTVmOjcyODM6MTFkOTpmODY6ZTY5MF0gmHxwqJfb2hUaNK1LVeqADvVhzASq1cV90sPYYfwX9CkiMi5kbnNjcnlwdC1jZXJ0LmRuc2NyeXB0LmNhLTItaXB2Ng
 
-## dnscrypt.dotya.ml
-Free, uncensored, DNSSEC-validated, non-logging DNSCrypt server hosted in Nuremberg, Germany
-on Contabo servers, operated by dotya.ml, configs live [here](https://git.dotya.ml/dotya.ml/dnscrypt-server). Available over both IPv4 and IPv6.
+## dotya.ml
 
-### IPv4
+Free, uncensored, DNSSEC-validated, non-logging DNSCrypt server hosted in Nuremberg, Germany
+on Contabo servers.
+Operated by dotya.ml, configs live here: https://git.dotya.ml/dotya.ml/dnscrypt-server.
+
+Available over both IPv4 and IPv6.
+
 sdns://AQcAAAAAAAAAETE0NC45MS43MC42Mjo1NDQzIHF-JiN46cNwFXJleEVWGWgrhe2QeysUtZoo9HwzYCMzITIuZG5zY3J5cHQtY2VydC5kbnNjcnlwdC5kb3R5YS5tbA
 
-### IPv6
+## dotya.ml-ipv6
+
+Free, uncensored, DNSSEC-validated, non-logging DNSCrypt server hosted in Nuremberg, Germany
+on Contabo servers.
+Operated by dotya.ml, configs live here: https://git.dotya.ml/dotya.ml/dnscrypt-server.
+
+Available over both IPv4 and IPv6.
+
 sdns://AQcAAAAAAAAAHFsyYTAyOmMyMDc6MjAzMDozOTY6OjFdOjU0NDMgcX4mI3jpw3AVcmV4RVYZaCuF7ZB7KxS1mij0fDNgIzMhMi5kbnNjcnlwdC1jZXJ0LmRuc2NyeXB0LmRvdHlhLm1s
 
 ## dnscrypt.eu-nl


### PR DESCRIPTION
as title, add dotya.ml-hosted DNSCrypt server(s).

before marking this as ready for review, I'd like to know whether there are any other ways to test the setup besides setting `servers` in `dnscrypt-proxy.toml` to subject resolvers, as in using sth like dig/kdig but for DNSCrypt.
another question I have is concerning OpenNIC - I'd like for my instance to be able to resolve OpenNIC domains and [this](https://git.dotya.ml/dotya.ml/dnscrypt-server/src/branch/development/etc/dnscrypt-server/zones/opennic-tlds.conf) is how I went about it...could someone with more DNS expertise please tell me whether that would work or suggest an improvement?