### PR TITLE
Re-add openinternet with updated stamp

### DIFF
--- a/v3/public-resolvers.md
+++ b/v3/public-resolvers.md
@@ -1717,6 +1717,13 @@ https://dns.njal.la/
 
 sdns://AgcAAAAAAAAADDk1LjIxNS4xOS41M6DMEGDTnIMptitvvH0NbfkwmGm5gefmOS1c2PpAj02A5iBETr1nu4P4gHs5Iek4rJF4uIK9UKrbESMfBEz18I33zgtkbnMubmphbC5sYQovZG5zLXF1ZXJ5
 
+## openinternet
+
+DNSCrypt resolver colocated at Sonic.net in Santa Rosa, CA in the United States.
+No log, no filter, DNSSEC. Provided by https://openinternet.io
+
+sdns://AQcAAAAAAAAAETcwLjM2LjE3MC4xMjY6NDQzIB0YaHUp4ep9JcpfE9HeXtjkmqbK5eOebLKTklv3C5UNHDIuZG5zY3J5cHQtY2VydC5vcGVuaW50ZXJuZXQ
+
 
 ## oszx
 

--- a/v3/relays.md
+++ b/v3/relays.md
@@ -412,6 +412,12 @@ Anonymized DNS relay hosted by MegaNerd.nl (IPv4) (https://www.meganerd.nl/encry
 
 sdns://gRIxMzYuMjQ0Ljk3LjExNDo0NDM
 
+## anon-openinternet
+
+Anonymized DNS relay colocated at Sonic.net in Santa Rosa, CA in the United States. Provided by https://openinternet.io
+
+sdns://gRE3MC4zNi4xNzAuMTI2OjQ0Mw
+
 
 ## anon-saldns01-conoha-ipv4
 


### PR DESCRIPTION
Initially added in PR #527, removed in 1dffcff1 and f9791046.

After some downtime due to hardware failure, the resolver is back up on new hardware using the same IP:port as before. The updated stamp uses a shorter provider name.
