### PR TITLE
Update opennic.md add opennameserver.org

### DIFF
--- a/v3/opennic.md
+++ b/v3/opennic.md
@@ -46,3 +46,21 @@ Maintained by publicarray - https://dns.seby.io
 
 sdns://AgcAAAAAAAAADTEzOS45OS4yMjIuNzKgzBBg05yDKbYrb7x9DW35MJhpuYHn5jktXNj6QI9NgOYgRE69Z7uD-IB7OSHpOKyReLiCvVCq2xEjHwRM9fCN984NZG9oLTIuc2VieS5pbwovZG5zLXF1ZXJ5
 
+
+## opennameserver-2-doh
+
+OpenNIC • DoH • DoT • DNSSEC • No Logging • Uncensored - https://opennameserver.org
+
+sdns://AgcAAAAAAAAAACBETr1nu4P4gHs5Iek4rJF4uIK9UKrbESMfBEz18I33zhZuczIub3Blbm5hbWVzZXJ2ZXIub3JnCi9kbnMtcXVlcnk
+
+## opennameserver-3-doh
+
+OpenNIC • DoH • DoT • DNSSEC • No Logging • Uncensored - https://opennameserver.org
+
+sdns://AgcAAAAAAAAAACBETr1nu4P4gHs5Iek4rJF4uIK9UKrbESMfBEz18I33zhZuczMub3Blbm5hbWVzZXJ2ZXIub3JnCi9kbnMtcXVlcnk
+
+## opennameserver-4-doh
+
+OpenNIC • DoH • DoT • DNSSEC • No Logging • Uncensored - https://opennameserver.org
+
+sdns://AgcAAAAAAAAAACBETr1nu4P4gHs5Iek4rJF4uIK9UKrbESMfBEz18I33zhZuczQub3Blbm5hbWVzZXJ2ZXIub3JnCi9kbnMtcXVlcnk


### PR DESCRIPTION
For some reason ns1.opennameserver.org not works for me. but it resolves properly without DoH `sdns://AgcAAAAAAAAAACBETr1nu4P4gHs5Iek4rJF4uIK9UKrbESMfBEz18I33zhZuczEub3Blbm5hbWVzZXJ2ZXIub3JnCi9kbnMtcXVlcnk`