### PR TITLE
Planned on BebasDNS Maintenance to support dnscrypt protocol

### DIFF
--- a/v3/public-resolvers.md
+++ b/v3/public-resolvers.md
@@ -229,20 +229,6 @@ AT&T test DoH server.
 sdns://AgUAAAAAAAAAAKC8hFRehaL-5iAWO74cDW6sa3toE6vGROtou_hQdtyuYyCY49XlNq8pWM0vfxT3BO9KJ20l4zzWXy5l9eTycnwTMBBkb2h0cmlhbC5hdHQubmV0Ci9kbnMtcXVlcnk
 
 
-## bebasdns
-
-BebasDNS default server by BebasID. DNSSEC supported. Filters ads, tracker, and malware.
-
-sdns://AgMAAAAAAAAADDEwMy44Ny42OC4yNCBETr1nu4P4gHs5Iek4rJF4uIK9UKrbESMfBEz18I33zg9kbnMuYmViYXNpZC5jb20KL2Rucy1xdWVyeQ
-
-
-## bebasdns-security
-
-BebasDNS Security Variant by BebasID. DNSSEC supported. Only blocks malicious links.
-
-sdns://AgMAAAAAAAAADDEwMy44Ny42OC4yMyBETr1nu4P4gHs5Iek4rJF4uIK9UKrbESMfBEz18I33zhVhbnRpdmlydXMuYmViYXNpZC5jb20KL2Rucy1xdWVyeQ
-
-
 ## bortzmeyer
 
 Non-logging DoH server in France operated by Stéphane Bortzmeyer.


### PR DESCRIPTION
Hello,

Can you remove our server please for temporary? We are planning to upgrade our server to support dnscrypt protocol so since this dns cannot be used on dnscrypt while we are upgrading, we decided to remove our server for temporary until the upgrade is completed.

Thanks