### PR TITLE
add tuna-doh-ipv6

### DIFF
--- a/v3/public-resolvers.md
+++ b/v3/public-resolvers.md
@@ -2032,6 +2032,13 @@ DoH server provided by Tsinghua University TUNA Association, located in mainland
 sdns://AgEAAAAAAAAACTEwMS42LjYuNiBZPi1Jp0AjVVUmrvm3QisZ5bixZzkbbe5e0pKxyiOnTA4xMDEuNi42LjY6ODQ0MwovZG5zLXF1ZXJ5
 
 
+## tuna-doh-ipv6
+
+DoH server provided by Tsinghua University TUNA Association, located in mainland China, no GFW poisoning yet it has a manual blacklist.
+
+sdns://AgEAAAAAAAAAG1syNDAyOmYwMDA6MTo0MTY6MTAxOjY6Njo2XSBZPi1Jp0AjVVUmrvm3QisZ5bixZzkbbe5e0pKxyiOnTB1kbnMudHVuYS50c2luZ2h1YS5lZHUuY246ODQ0MwovZG5zLXF1ZXJ5
+
+
 ## uncensoreddns-dk-ipv4
 
 Also known as censurfridns.


### PR DESCRIPTION
They also provide IPv6 access, but unlike 101.6.6.6, it doesn't have a for-IP TLS certificate.