### PR TITLE
Update moedns-doh description

### DIFF
--- a/v3/public-resolvers.md
+++ b/v3/public-resolvers.md
@@ -2165,7 +2165,7 @@ sdns://AQcAAAAAAAAAJ1syMDAxOjE5ZjA6NTAwMTpjYmI6NTQwMDozZmY6ZmUwNzpmNzBkXSAon-lfT
 
 ## moedns-doh
 
-DoH server in mainland China operated by [Nyarime](https://about.x.gy), powered by AdGuard Home. Intro page: https://x.gy/article/moedns
+DoH server in mainland China operated by [Nyarime](https://naixi.net/), powered by AdGuard Home. Intro page: https://blog.naixi.net/article/moedns
 
 Keeps logs for 90 days according to law, filters ads and malicious websites, supports DNSSEC, no GFW poisoning
 


### PR DESCRIPTION
The operator recently changed both their blog and homepage domain.

<details><summary>drama</summary>

It all started when I found out that the post about clean DNS had disappeared from her blog, and my first reaction was: this must be censorship, she was ordered by the authorities to cancel the service. But after testing, the service is still running. I then sent an email to inquire, and her response was as expected.

The first line says that the blog post disappeared because the domain name of the blog was "not synchronized in time".
second line, Google translated.

> Secondly, due to the recent notification from relevant departments. It is said that many VPN businesses involve this DNS service. Although we have carried out registration and approval procedures, we still received many reports. MoeDNS was established only for employees to use with the company's intranet outside, similar to dns.itxe and other intranet resource access. We do not want this server to be publicized and taken seriously by relevant departments, and eventually be forced to shut down.

In the third line, she stated that the domain name of the blog has changed and she hopes DNSCrypt will update it.

After reading the email, I opened the original blog link again and saw that this blog post had been restored, but it was just published today, and the content seemed to be different from before, such as the word "pollution-free" was deleted.

This is of course expected. In China, if you provide pollution-free DNS, it is tantamount to assisting in circumventing the wall. I very much doubt that this service can run for more than 3 months without authorities forcing her to shut down the service. Until then, let's wait and see.

By the way, the clean DoH previously operated by iqdns and rubyfish has been either offline or removed.

</details>