### PR TITLE
remove moedns

### DIFF
--- a/v3/public-resolvers.md
+++ b/v3/public-resolvers.md
@@ -2163,15 +2163,6 @@ Non-logging, non-filtering, supports DNSSEC.
 sdns://AQcAAAAAAAAAJ1syMDAxOjE5ZjA6NTAwMTpjYmI6NTQwMDozZmY6ZmUwNzpmNzBkXSAon-lfTOhBf_V6PzB8JAzeGSYxEaKUiTfIQblFoPWHjCUyLmRuc2NyeXB0LWNlcnQuY2hld2JhY2NhLm1lZ2FuZXJkLm5s
 
 
-## moedns-doh
-
-DoH server in mainland China operated by [Nyarime](https://naixi.net/), powered by AdGuard Home. Intro page: https://blog.naixi.net/article/moedns
-
-Keeps logs for 90 days according to law, filters ads and malicious websites, supports DNSSEC, no GFW poisoning
-
-sdns://AgEAAAAAAAAAACAl3vkEVF7va7q6n3EiBtr_9_TGsyZQ7-RvpLpJtdqibA1wZG5zLml0eGUubmV0Ci9kbnMtcXVlcnk
-
-
 ## mullvad-adblock-doh
 
 Same as mullvad but blocking ads and trackers.


### PR DESCRIPTION
As expected, all poisoning-free dns in China are very short-life.

> Because the DNS (Internet domain name resolution service business) of my subsidiary's B2 qualification is within the scope of Jiangsu Province. At present, there is a problem that the qualifications are not consistent with the actual situation, and the current statement is that it was reported by others.
>
> At the request of the Jiangsu Provincial Administration, MoeDNS will be officially offline on September 9, 2023, and will be resumed after obtaining national qualifications in the future. Although I have been alive for 4 months, it is really hard to see so many users, and I am very grateful for everyone's support.
>
>In order to ensure that your device can connect to the Internet normally. We ask that you correct your DNS records within 72 hours to ensure that your device is not affected. We apologize for the inconvenience.
>
> Nyarime
> 2023/9/6
>
>-- https://t.me/s/NyarimeW/4316