### PR TITLE
PureDNS and RethinkDNS

### DIFF
--- a/v3/public-resolvers.md
+++ b/v3/public-resolvers.md
@@ -2445,7 +2445,8 @@ DNSSEC, No-filter, No-log by https://upset.dev
 Servers in Singapore and Indonesia  
 Homepage: https://puredns.org
 
-sdns://AgcAAAAAAAAAAAALcHVyZWRucy5vcmcKL2Rucy1xdWVyeQ
+sdns://AgcAAAAAAAAACjMuMS45NC4yMTggWu-EP_zy7HBV9QShYvIp-DkcNw_zphY9LbPz1gTWIr4LcHVyZWRucy5vcmcKL2Rucy1xdWVyeQ
+sdns://AgcAAAAAAAAACjMuMC44Ni4xMjYgWu-EP_zy7HBV9QShYvIp-DkcNw_zphY9LbPz1gTWIr4LcHVyZWRucy5vcmcKL2Rucy1xdWVyeQ
 
 
 ## qihoo360-doh

--- a/v3/public-resolvers.md
+++ b/v3/public-resolvers.md
@@ -2441,12 +2441,22 @@ sdns://AgcAAAAAAAAADTEzOS45OS4yMjIuNzKgzBBg05yDKbYrb7x9DW35MJhpuYHn5jktXNj6QI9Ng
 
 ## puredns-doh
 
-DNSSEC, No-filter, No-log by https://upset.dev  
+DNSSEC, No-log, No-filter by https://upset.dev  
 Servers in Singapore and Indonesia  
 Homepage: https://puredns.org
 
 sdns://AgcAAAAAAAAACjMuMS45NC4yMTggWu-EP_zy7HBV9QShYvIp-DkcNw_zphY9LbPz1gTWIr4LcHVyZWRucy5vcmcKL2Rucy1xdWVyeQ
 sdns://AgcAAAAAAAAACjMuMC44Ni4xMjYgWu-EP_zy7HBV9QShYvIp-DkcNw_zphY9LbPz1gTWIr4LcHVyZWRucy5vcmcKL2Rucy1xdWVyeQ
+
+
+## puredns-family-doh
+
+DNSSEC, No-log, with malware, adware, gambling, fakenews, and NSFW blocking by https://upset.dev  
+Servers in Singapore and Indonesia  
+Homepage: https://puredns.org/family
+
+sdns://AgMAAAAAAAAADTEwOC4xMzcuNDQuMzMgWu-EP_zy7HBV9QShYvIp-DkcNw_zphY9LbPz1gTWIr4SZmFtaWx5LnB1cmVkbnMub3JnCi9kbnMtcXVlcnk
+sdns://AgMAAAAAAAAADDEwOC4xMzcuMzUuNCBa74Q__PLscFX1BKFi8in4ORw3D_OmFj0ts_PWBNYivhJmYW1pbHkucHVyZWRucy5vcmcKL2Rucy1xdWVyeQ
 
 
 ## qihoo360-doh

--- a/v3/public-resolvers.md
+++ b/v3/public-resolvers.md
@@ -2439,6 +2439,15 @@ Maintained by publicarray - https://dns.seby.io
 sdns://AgcAAAAAAAAADTEzOS45OS4yMjIuNzKgzBBg05yDKbYrb7x9DW35MJhpuYHn5jktXNj6QI9NgOYgRE69Z7uD-IB7OSHpOKyReLiCvVCq2xEjHwRM9fCN984NZG9oLTIuc2VieS5pbwovZG5zLXF1ZXJ5
 
 
+## puredns-doh
+
+DNSSEC, No-filter, No-log by https://upset.dev  
+Servers in Singapore and Indonesia  
+Homepage: https://puredns.org
+
+sdns://AgcAAAAAAAAAAAALcHVyZWRucy5vcmcKL2Rucy1xdWVyeQ
+
+
 ## qihoo360-doh
 
 DoH server runned by Qihoo 360, has logs, supports DNSSEC. GFW filtering rules are applied.

--- a/v3/public-resolvers.md
+++ b/v3/public-resolvers.md
@@ -2640,6 +2640,16 @@ sdns://AgYAAAAAAAAADVsyNjIwOmZlOjoxMF0gKhX11qy258CQGt5Ou8dDsszUiQMrRuFkLwaTaDABJ
 sdns://AgYAAAAAAAAAEFsyNjIwOmZlOjpmZToxMF0gKhX11qy258CQGt5Ou8dDsszUiQMrRuFkLwaTaDABJYoUZG5zMTAucXVhZDkubmV0OjUwNTMKL2Rucy1xdWVyeQ
 
 
+## rethinkdns-doh
+
+DNSSEC, No-log, No-filter  
+RethinkDNS, a stub (sky.rethinkdns.com hosted on Cloudflare) and recursive (max.rethinkdns.com hosted on fly.io) resolver  
+The stub server strips identification parameters from the request and acts as a proxy to another recursive resolver.
+
+sdns://AgcAAAAAAAAAACARsQLmsfY-UomE1gJfMrE4JB_Ii711GVdNcMmDLVPh6BJza3kucmV0aGlua2Rucy5jb20KL2Rucy1xdWVyeQ
+sdns://AgcAAAAAAAAAACAyme2vEQzyViN8wggmaizWRjeVcfgKsF4V7mc1KEui0hJtYXgucmV0aGlua2Rucy5jb20KL2Rucy1xdWVyeQ
+
+
 ## safesurfer
 
 Family safety focused blocklist for over 2 million adult sites, as well as phishing and malware and more.


### PR DESCRIPTION
# PureDNS
```
[NOTICE] Advertised cert: [CN=puredns.org] [d8ba6005b6fe6093c1ecba14eec8ba48220dc12ce935ff42e74624e7881eef9c]
[NOTICE] Advertised cert: [CN=E1,O=Let's Encrypt,C=US] [cc1060d39c8329b62b6fbc7d0d6df9309869b981e7e6392d5cd8fa408f4d80e6]
[NOTICE] Advertised cert: [CN=ISRG Root X2,O=Internet Security Research Group,C=US] [5aef843ffcf2ec7055f504a162f229f8391c370ff3a6163d2db3f3d604d622be]
```
# RethinkDNS (both domains)
https://github.com/serverless-dns/serverless-dns#the-rethinkdns-resolver
```
[NOTICE] Resolving server host [sky.rethinkdns.com]
[NOTICE] Advertised cert: [CN=rethinkdns.com] [1cb947f3f723167d89cba03ea16cec0f54225ec31ae01e293402714ec25e95ea]
[NOTICE] Advertised cert: [CN=E1,O=Let's Encrypt,C=US] [cc1060d39c8329b62b6fbc7d0d6df9309869b981e7e6392d5cd8fa408f4d80e6]
[NOTICE] Advertised cert: [CN=ISRG Root X2,O=Internet Security Research Group,C=US] [5aef843ffcf2ec7055f504a162f229f8391c370ff3a6163d2db3f3d604d622be]
[NOTICE] Advertised cert: [CN=ISRG Root X1,O=Internet Security Research Group,C=US] [11b102e6b1f63e528984d6025f32b138241fc88bbd7519574d70c9832d53e1e8]
```

```
[NOTICE] Resolving server host [max.rethinkdns.com]
[NOTICE] Advertised cert: [CN=max.rethinkdns.com] [fa75e7413b4107d8adec3731f5009ac1181a8f296a03ac1317175aa3c5cd0551]
[NOTICE] Advertised cert: [CN=ZeroSSL ECC Domain Secure Site CA,O=ZeroSSL,C=AT] [9a3a34f727deb9bca51003d9ce9c39f8f27dd9c5242901c2bab1a44e635a0219]
[NOTICE] Advertised cert: [CN=USERTrust ECC Certification Authority,O=The USERTRUST Network,L=Jersey City,ST=New Jersey,C=US] [3299edaf110cf256237cc208266a2cd646379571f80ab05e15ee6735284ba2d2]
```