### PR TITLE
Update the IP of BebasDNS Unfiltered DNSCrypt 

### DIFF
--- a/v2/public-resolvers.md
+++ b/v2/public-resolvers.md
@@ -226,11 +226,11 @@ BebasDNS default server by BebasID. DNSSEC and OpenNIC supported. Filters ads, t
 sdns://AQMAAAAAAAAAEjEwMy44Ny42OC4xOTQ6ODQ0MyAxXDKkdrOao8ZeLyu7vTnVrT0C7YlPNNf6trdMkje7QR8yLmRuc2NyeXB0LWNlcnQuZG5zLmJlYmFzaWQuY29t
 
 
-## bebasdns-dnscrypt
+## bebasdns-unfiltered-dnscrypt
 
 BebasDNS by BebasID. DNSSEC and OpenNIC supported. This variant is unfiltered and using DNSCrypt protocol.
 
-sdns://AQcAAAAAAAAAEzM0LjEwMS4xODUuMTMwOjU0NDMghpbY0AAjPtvOiDsSzDh7Few4-cUrb6D33KwcMl75TtkqMi5kbnNjcnlwdC1jZXJ0LnVuZmlsdGVyZWQuZG5zLmJlYmFzaWQuY29t
+sdns://AQcAAAAAAAAAEjM1LjIxOS42Ny4xNTA6NTQ0MyAtDC9I4194j3U0lZcEBPPd43IvR8gGNOS5QNVIx_7PNyoyLmRuc2NyeXB0LWNlcnQudW5maWx0ZXJlZC5kbnMuYmViYXNpZC5jb20
 
 
 ## bebasdns-family
@@ -247,7 +247,7 @@ BebasDNS Security Variant by BebasID. DNSSEC and OpenNIC supported. Only blocks 
 sdns://AQMAAAAAAAAAEjEwMy44Ny42OC4xOTU6ODQ0MyDxbZzPMadetG2FodrzRfoiJjJi3cxbOsvKAvMyJ09rfiUyLmRuc2NyeXB0LWNlcnQuYW50aXZpcnVzLmJlYmFzaWQuY29t
 
 
-## bebasdns-unfiltered
+## bebasdns-unfiltered-doh
 
 BebasDNS by BebasID. DNSSEC and OpenNIC supported. This variant doesn't block anything
 


### PR DESCRIPTION
Our IP has changed from 34.101.185.130 to 35.219.67.150 thus we are updating our DNSCrypt stamp.

Please take a look