### PR TITLE
Re-adding tirapan.top

### DIFF
--- a/v3/public-resolvers.md
+++ b/v3/public-resolvers.md
@@ -3224,6 +3224,20 @@ No filter | No logs | DNSSEC | Nuremberg, Germany (netcup) | Maintained by https
 sdns://AQcAAAAAAAAAEDg5LjU4LjYuMTY5OjQ0MzQgB4isFl7gD2-efHhMEtFjyCz_nHFCaQ8OsbBTgZCa3zsgMi5kbnNjcnlwdC1jZXJ0LnRlY2hzYXZpb3Vycy5vcmc
 
 
+## tirapan-doh-ipv4
+
+Recursive and caching resolver, no-log/filter, DNSSEC. Homepage: https://www.tirapan.top
+
+sdns://AgcAAAAAAAAADDkxLjEwNy4yMzUuMCBETr1nu4P4gHs5Iek4rJF4uIK9UKrbESMfBEz18I33zgt0aXJhcGFuLnRvcBAvbm9tZW4tcXVhZXNpdHVt
+
+
+## tirapan-doh-ipv6
+
+Recursive and caching resolver, no-log/filter, DNSSEC, IPv6 variant. Homepage: https://www.tirapan.top
+
+sdns://AgcAAAAAAAAAF1syYTAxOjRmODoxYzFlOjhjYmE6OjFdIEROvWe7g_iAezkh6TiskXi4gr1QqtsRIx8ETPXwjffOC3RpcmFwYW4udG9wEC9ub21lbi1xdWFlc2l0dW0
+
+
 ## tuna-doh-ipv6
 
 DoH server provided by Tsinghua University TUNA Association, located in mainland China, no GFW poisoning yet it has a manual blacklist.


### PR DESCRIPTION
Problem with caddy and h3:
https://github.com/caddyserver/caddy/issues/5086#issuecomment-2094529691

Problem with DoH proxy:
https://github.com/m13253/dns-over-https?tab=readme-ov-file#known-issues

So unless anyone can suggest a way to simultaneously have the two of them (https server and DoH proxy) listen on 443, all I can do is wait for them to get fixed/implemented.
