### PR TITLE
changed techsaviours.org to digitalprivacy.diy

### DIFF
--- a/v3/public-resolvers.md
+++ b/v3/public-resolvers.md
@@ -965,6 +965,13 @@ Encrypted DNS Server image by jedisct1, maintaned by DeffeR.
 sdns://AQcAAAAAAAAADTUyLjY1LjIzNS4xMjkg5Q00RDDBkwx3fUaa0_etjz4iH3lLBOqsg95bYDmV07MdMi5kbnNjcnlwdC1jZXJ0LmRlZmZlci1kbnMuYXU
 
 
+## digitalprivacy.diy-dnscrypt
+
+No filter | No logs | DNSSEC | Nuremberg, Germany (netcup) | Maintained by https://digitalprivacy.diy/
+
+sdns://AQcAAAAAAAAAEjM3LjIyMS4xOTQuODQ6NDQzNCCiyGRvm0TcyJmI7lTXstgh-8AoAAiFcTQQp7Od_brTYCIyLmRuc2NyeXB0LWNlcnQuZGlnaXRhbHByaXZhY3kuZGl5
+
+
 ## dns.digitale-gesellschaft.ch
 
 Public DoH resolver operated by the Digital Society (https://www.digitale-gesellschaft.ch).
@@ -3416,13 +3423,6 @@ Homepage: https://www.switch.ch
 
 sdns://AgMAAAAAAAAAACCwGSB0S7t2yasFPgHge34FDkc9IPefe-pDX6_kPJ0kLxJbMjAwMTo2MjA6MDpmZjo6Ml0KL2Rucy1xdWVyeQ
 sdns://AgMAAAAAAAAAACCwGSB0S7t2yasFPgHge34FDkc9IPefe-pDX6_kPJ0kLxJbMjAwMTo2MjA6MDpmZjo6M10KL2Rucy1xdWVyeQ
-
-
-## techsaviours.org-dnscrypt
-
-No filter | No logs | DNSSEC | Nuremberg, Germany (netcup) | Maintained by https://techsaviours.org/
-
-sdns://AQcAAAAAAAAAEDg5LjU4LjYuMTY5OjQ0MzQgB4isFl7gD2-efHhMEtFjyCz_nHFCaQ8OsbBTgZCa3zsgMi5kbnNjcnlwdC1jZXJ0LnRlY2hzYXZpb3Vycy5vcmc
 
 
 ## tirapan-doh-ipv4

--- a/v3/relays.md
+++ b/v3/relays.md
@@ -526,13 +526,6 @@ Anonymized DNS relay hosted in Sweden - SE
 sdns://gRI0NS4xNTMuMTg3Ljk2OjQzNDM
 
 
-## anon-techsaviours.org
-
-Anonymized DNS relay hosted in Nuremberg, Germany (netcup) and maintained by https://techsaviours.org
-
-sdns://gRA4OS41OC42LjE2OTo0NDM0
-
-
 ## anon-tiarap
 
 Anonymized DNS relay hosted in Singapore
@@ -730,6 +723,13 @@ DNSCry.pt Coventry - DNSCrypt, no filter, no logs, DNSSEC support (IPv6 server)
 https://www.dnscry.pt
 
 sdns://gSBbMmEwYzpiODQwOjI6MTYyOjE4MDg6MDoxYzo5YjZjXQ
+
+
+## anon-digitalprivacy.diy
+
+Anonymized DNS relay hosted in Nuremberg, Germany (netcup) and maintained by https://digitalprivacy.diy
+
+sdns://gRIzNy4yMjEuMTk0Ljg0OjQ0MzQ
 
 
 ## dnscry.pt-anon-dallas-ipv4


### PR DESCRIPTION
We've changed the name to DIGITAL PRIVACY .DIY instead of TECH SAVIOURS .ORG.  
Therefore, we have set up a new server, new domains and new services.

techsaviours.org dnscrypt will be still maintained and available until 25 Oct 24.