### PR TITLE
Update ksol.io public resolver

### DIFF
--- a/v2/public-resolvers.md
+++ b/v2/public-resolvers.md
@@ -3054,14 +3054,14 @@ sdns://AgcAAAAAAAAAG1syNjA2OjQ3MDA6MzAzMDo6YWM0MzphZDNiXQANanAudGlhcmFwLm9yZwovZ
 
 DNSCrypt on IPv4 (UDP/TCP). No DoH, doesn't log, doesn't filter, DNSSEC enforced. No EDNS Client-Subnet, padding enabled, as per `dnscrypt-server-docker` default unbound configuration. Location: Hungary
 
-sdns://AQcAAAAAAAAADjE5My4yMDEuMTg4LjQ4IBERKdQJgLSjqCSK99e2f_WRTQzEq9__DeXlQFvxxhZ6GzIuZG5zY3J5cHQtY2VydC5uczIua3NvbC5pbw
+sdns://AQcAAAAAAAAAEjE5My4yMDEuMTg4LjQ4OjQ0MyARESnUCYC0o6gkivfXtn_1kU0MxKvf_w3l5UBb8cYWehsyLmRuc2NyeXB0LWNlcnQubnMyLmtzb2wuaW8
 
 
 ## ksol.io-ns2-dnscrypt-ipv6
 
 DNSCrypt on IPv6 (UDP/TCP). No DoH, doesn't log, doesn't filter, DNSSEC enforced. No EDNS Client-Subnet, padding enabled, as per `dnscrypt-server-docker` default unbound configuration. Location: Hungary
 
-sdns://AQcAAAAAAAAAFFsyYTAxOjZlZTA6MTo6MjQxOjFdIBERKdQJgLSjqCSK99e2f_WRTQzEq9__DeXlQFvxxhZ6GzIuZG5zY3J5cHQtY2VydC5uczIua3NvbC5pbw
+sdns://AQcAAAAAAAAAGFsyYTAxOjZlZTA6MTo6MjQxOjFdOjQ0MyARESnUCYC0o6gkivfXtn_1kU0MxKvf_w3l5UBb8cYWehsyLmRuc2NyeXB0LWNlcnQubnMyLmtzb2wuaW8
 
 
 ## libredns

--- a/v3/public-resolvers.md
+++ b/v3/public-resolvers.md
@@ -3133,14 +3133,14 @@ sdns://AgcAAAAAAAAAG1syNjA2OjQ3MDA6MzAzMDo6YWM0MzphZDNiXQANanAudGlhcmFwLm9yZwovZ
 
 DNSCrypt on IPv4 (UDP/TCP). No DoH, doesn't log, doesn't filter, DNSSEC enforced. No EDNS Client-Subnet, padding enabled, as per `dnscrypt-server-docker` default unbound configuration. Location: Hungary
 
-sdns://AQcAAAAAAAAADjE5My4yMDEuMTg4LjQ4IBERKdQJgLSjqCSK99e2f_WRTQzEq9__DeXlQFvxxhZ6GzIuZG5zY3J5cHQtY2VydC5uczIua3NvbC5pbw
+sdns://AQcAAAAAAAAAEjE5My4yMDEuMTg4LjQ4OjQ0MyARESnUCYC0o6gkivfXtn_1kU0MxKvf_w3l5UBb8cYWehsyLmRuc2NyeXB0LWNlcnQubnMyLmtzb2wuaW8
 
 
 ## ksol.io-ns2-dnscrypt-ipv6
 
 DNSCrypt on IPv6 (UDP/TCP). No DoH, doesn't log, doesn't filter, DNSSEC enforced. No EDNS Client-Subnet, padding enabled, as per `dnscrypt-server-docker` default unbound configuration. Location: Hungary
 
-sdns://AQcAAAAAAAAAFFsyYTAxOjZlZTA6MTo6MjQxOjFdIBERKdQJgLSjqCSK99e2f_WRTQzEq9__DeXlQFvxxhZ6GzIuZG5zY3J5cHQtY2VydC5uczIua3NvbC5pbw
+sdns://AQcAAAAAAAAAGFsyYTAxOjZlZTA6MTo6MjQxOjFdOjQ0MyARESnUCYC0o6gkivfXtn_1kU0MxKvf_w3l5UBb8cYWehsyLmRuc2NyeXB0LWNlcnQubnMyLmtzb2wuaW8
 
 
 ## libredns


### PR DESCRIPTION
For some reason, upon updating the docker container `jedisct1/dnscrypt-server`, it changed my server's keys.

This update uses the new keys.