### PR TITLE
update IP addresses for dnscry.pt-johor-ipv[46]

### DIFF
--- a/v3/public-resolvers.md
+++ b/v3/public-resolvers.md
@@ -1987,7 +1987,7 @@ DNSCry.pt Johor - DNSCrypt, no filter, no logs, DNSSEC support (IPv4 server)
 
 https://www.dnscry.pt
 
-sdns://AQcAAAAAAAAACzE2MC4zMC41LjEyIEqgV701rJQq50ORl-HqG20LWx8W30NVOc0svAL2cI2kGTIuZG5zY3J5cHQtY2VydC5kbnNjcnkucHQ
+sdns://AQcAAAAAAAAADTQ1LjI0OS45MS4xNTAgHONiOhMA1VOPBBcvrkvy9IW-Q0dhA1aY-g5rKbpy9noZMi5kbnNjcnlwdC1jZXJ0LmRuc2NyeS5wdA
 
 
 ## dnscry.pt-johor-ipv6
@@ -1996,7 +1996,7 @@ DNSCry.pt Johor - DNSCrypt, no filter, no logs, DNSSEC support (IPv6 server)
 
 https://www.dnscry.pt
 
-sdns://AQcAAAAAAAAAFVsyMDAxOmRmNDoxODQwOjJmOjphXSBKoFe9NayUKudDkZfh6httC1sfFt9DVTnNLLwC9nCNpBkyLmRuc2NyeXB0LWNlcnQuZG5zY3J5LnB0
+sdns://AQcAAAAAAAAAFVsyMDAxOmRmNDoxODQwOjlmOjphXSAc42I6EwDVU48EFy-uS_L0hb5DR2EDVpj6DmspunL2ehkyLmRuc2NyeXB0LWNlcnQuZG5zY3J5LnB0
 
 
 ## dnscry.pt-kansascity-ipv4

--- a/v3/relays.md
+++ b/v3/relays.md
@@ -1294,7 +1294,7 @@ DNSCry.pt Johor - DNSCrypt, no filter, no logs, DNSSEC support (IPv4 server)
 
 https://www.dnscry.pt
 
-sdns://gQsxNjAuMzAuNS4xMg
+sdns://gQ00NS4yNDkuOTEuMTUw
 
 
 ## dnscry.pt-anon-johor-ipv6
@@ -1303,7 +1303,7 @@ DNSCry.pt Johor - DNSCrypt, no filter, no logs, DNSSEC support (IPv6 server)
 
 https://www.dnscry.pt
 
-sdns://gRVbMjAwMTpkZjQ6MTg0MDoyZjo6YV0
+sdns://gRVbMjAwMTpkZjQ6MTg0MDo5Zjo6YV0
 
 
 ## dnscry.pt-anon-kansascity-ipv4


### PR DESCRIPTION
IP addresses for jhb01.dnscry.pt have changed.

_I've made the changes only to the `v3` directory as stated in https://github.com/DNSCrypt/dnscrypt-resolvers/blob/master/CONTRIBUTING.md. Please let me know if changes should be added to v1/v2 as well._