### PR TITLE
Add j78 (shortened name)

### DIFF
--- a/v3/public-resolvers.md
+++ b/v3/public-resolvers.md
@@ -2980,6 +2980,13 @@ https://www.dnscrypt.uk
 sdns://AQcAAAAAAAAAGlsyYTAzOmIwYzA6MTplMDo6NDg3OjEwMDFdIAHTDugOIE3aGHHToQ8oUVRnZb8UtNpEBKT_BG19qWg8GzIuZG5zY3J5cHQtY2VydC5kbnNjcnlwdC51aw
 
 
+## j78
+
+Hosted in Frankfurt am Main, Germany. Provides encrypted DNS over TLS with a focus on privacy. Supports DNSSEC and anonymized DNS relays. No persistent logs and no filtering.
+
+sdns://AQcAAAAAAAAADzE3Mi4yMzYuMjA2LjE0NSBnWDTijOYkXn_ihufvYNU1Q5wu4xa884qLbgQcPGZzCCAyLmRuc2NyeXB0LWNlcnQuZG5zY3J5cHQuajc4Lm9yZw
+
+
 ## dnsforfamily
 
 (DNSCrypt Protocol) (Now supports DNSSEC). Block adult websites, gambling websites, malwares, trackers and advertisements.


### PR DESCRIPTION
 docker logs dnscrypt_dnscrypt.1.ncfzxhf6easx6i2kd7ciqlmhx
[INFO  encrypted_dns] Dropping privileges
[INFO  encrypted_dns] State file [/opt/encrypted-dns/etc/keys/state/encrypted-dns.state] found; using existing provider key [INFO  encrypted_dns] Public server address: 172.236.206.145:443 [INFO  encrypted_dns] Provider public key: 675834e28ce6245e7fe286e7ef60d535439c2ee316bcf38a8b6e041c3c667308 [INFO  encrypted_dns] Provider name: 2.dnscrypt-cert.dnscrypt.j78.org [INFO  encrypted_dns] DNS Stamp: sdns://AQcAAAAAAAAAEzE3Mi4yMzYuMjA2LjE0NTo0NDMgZ1g04ozmJF5_4obn72DVNUOcLuMWvPOKi24EHDxmcwggMi5kbnNjcnlwdC1jZXJ0LmRuc2NyeXB0Lmo3OC5vcmc [INFO  encrypted_dns] DNS Stamp for Anonymized DNS relaying: sdns://gRMxNzIuMjM2LjIwNi4xNDU6NDQz root@dnscrypt:/etc/dnscrypt-server# dnslookup google.com sdns://AQcAAAAAAAAAEzE3Mi4yMzYuMjA2LjE0NTo0NDMgZ1g04ozmJF5_4obn72DVNUOcLuMWvPOKi24EHDxmcwggMi5kbnNjcnlwdC1jZXJ0LmRuc2NyeXB0Lmo3OC5vcmc dnslookup 1.11.1-11969
Server: sdns://AQcAAAAAAAAAEzE3Mi4yMzYuMjA2LjE0NTo0NDMgZ1g04ozmJF5_4obn72DVNUOcLuMWvPOKi24EHDxmcwggMi5kbnNjcnlwdC1jZXJ0LmRuc2NyeXB0Lmo3OC5vcmc

dnslookup result (elapsed 1.26682ms):
;; opcode: QUERY, status: NOERROR, id: 42612
;; flags: qr rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version 0; flags:; udp: 1232

;; QUESTION SECTION:
;google.com.    IN       A

;; ANSWER SECTION:
google.com.     3315    IN      A       142.250.186.174