### PR TITLE
fix: dns4all filtering policy

### DIFF
--- a/v3/public-resolvers.md
+++ b/v3/public-resolvers.md
@@ -1311,7 +1311,7 @@ sdns://AgcAAAAAAAAAACCaOjT3J965vKUQA9nOnDn48n3ZxSQpAcK6saROY1oCGQxvcGVuLmRuczAuZ
 
 ## dns4all-ipv4
 
-A DoH, DoT and DoQ resolver operated by sidnlabs.nl. No-logs, DNSSEC and No-filter.
+A DoH, DoT and DoQ resolver operated by sidnlabs.nl. No-logs, DNSSEC, Filters domains sanctioned by the EU.
 Homepage: https://dns4all.eu
 
 sdns://AgcAAAAAAAAACTE5NC4wLjUuMwAOZG9xLmRuczRhbGwuZXUKL2Rucy1xdWVyeQ
@@ -1320,7 +1320,7 @@ sdns://AgcAAAAAAAAACjE5NC4wLjUuNjQAEGRvcTY0LmRuczRhbGwuZXUKL2Rucy1xdWVyeQ
 
 ## dns4all-ipv6
 
-A DoH, DoT and DoQ resolver operated by sidnlabs.nl over IPv6. No-logs, DNSSEC and No-filter.
+A DoH, DoT and DoQ resolver operated by sidnlabs.nl over IPv6. No-logs, DNSSEC, Filters domains sanctioned by the EU.
 Homepage: https://dns4all.eu
 
 sdns://AgcAAAAAAAAAD1syMDAxOjY3ODo4OjozXQAOZG9xLmRuczRhbGwuZXUKL2Rucy1xdWVyeQ


### PR DESCRIPTION
According to [DNS4All](https://dns4all.eu/) landing page under the `Blocks` section:

> In accordance with [EU sanctions](https://eur-lex.europa.eu/legal-content/EN/TXT/PDF/?uri=CELEX:32022R0350), the domain names of the organizations listed in Annex XV of [this EU regulation](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:02014R0833-20250521#anx_XV) are blocked.
>
> If feel you we missed something, please do not hesitate to reach out to us. Also, see [this website](https://www.opensanctions.org/entities/NK-5xU2etvgAmWmnF83t6xqWb/).

<img width="787" height="341" alt="image" src="https://github.com/user-attachments/assets/c6d44fad-fe9e-41b7-9ffd-74f12e4a3d45" />
