### PR TITLE
Add ADnull personal DoH resolver

### DIFF
--- a/v3/public-resolvers.md
+++ b/v3/public-resolvers.md
@@ -193,6 +193,16 @@ Warning: This server is incompatible with anonymization.
 sdns://AQcAAAAAAAAAFlsyYTEwOjUwYzA6OjE6ZmZdOjU0NDMgtehE1rg6Pj4SaOtoH76nDePF-mjb1ogUHb8uwGay2volMi5kbnNjcnlwdC51bmZpbHRlcmVkLm5zMS5hZGd1YXJkLmNvbQ
 sdns://AQcAAAAAAAAAFlsyYTEwOjUwYzA6OjI6ZmZdOjU0NDMgtehE1rg6Pj4SaOtoH76nDePF-mjb1ogUHb8uwGay2volMi5kbnNjcnlwdC51bmZpbHRlcmVkLm5zMS5hZGd1YXJkLmNvbQ
 
+## adnull
+
+Personal DoH resolver with ad, tracker and malware blocking.
+Operated by ADnull. Custom subdomain per user account.
+No permanent query logging.
+
+https://adnull.com
+
+sdns://AgMAAAAAAAAAEFsxODguMTkwLjE5MS43OF0ADmRucy5hZG51bGwuY29tCi9kbnMtcXVlcnk
+
 
 ## alidns-doh
 


### PR DESCRIPTION
Adding ADnull — a personal DNS-over-HTTPS resolver with ad, tracker and malware blocking.

  - DoH URL: https://dns.adnull.com/dns-query
  - IPv4: 188.190.191.78 / 188.190.191.52
  - Tested with dnscrypt-proxy ✓
  - Privacy policy: https://adnull.com/en/privacy-policy