### PR TITLE
Add odohrelay-numa

### DIFF
--- a/v3/odoh-relays.md
+++ b/v3/odoh-relays.md
@@ -27,3 +27,11 @@ Maintained by Frank Denis.
 
 sdns://hQcAAAAAAAAAAAAab2RvaC1yZWxheS5lZGdlY29tcHV0ZS5hcHABLw
 
+
+## odohrelay-numa
+
+Oblivious DoH relay run by the Numa project on Hetzner (Falkenstein, Germany). https://numa.rs
+Maintained by Razvan Dimescu.
+
+sdns://hQcAAAAAAAAAAAASb2RvaC1yZWxheS5udW1hLnJzBi9yZWxheQ
+


### PR DESCRIPTION
Adds `odohrelay-numa`, a new ODoH relay run by the [Numa](https://github.com/razvandimescu/numa) project.

- **Host:** Hetzner Cloud, FSN1 (Falkenstein, Germany)
- **Stack:** Caddy terminating TLS (Let's Encrypt) in front of a minimal relay binary. Per-request access logs are disabled ([Caddyfile](https://github.com/razvandimescu/numa/blob/main/packaging/relay/Caddyfile)). The relay exposes only aggregate counters at `/health`. 
- **Deploy recipe:** [`packaging/relay/`](https://github.com/razvandimescu/numa/tree/main/packaging/relay) - anyone can reproduce the setup. 

**Operational status** (at time of PR):
- Uptime: 54h
- Total requests: ~51,200
- Forwarded OK: 99.48%
- `forwarded_err` / `rejected_bad_request`: 0

**Stamp validation:**

- `dnscrypt-proxy 2.1.15 -check` parses the stamp and accepts the route `[odoh-cloudflare] via [odohrelay-numa]`.                            
- Live-fire: 5 test queries through `dnscrypt-proxy` returned correct answers and incremented the relay's `total` counter by exactly 5.