### PR TITLE
Update onion-services url

### DIFF
--- a/v3/onion-services.md
+++ b/v3/onion-services.md
@@ -12,7 +12,7 @@ To use that list, add this to the `[sources]` section of your
 `dnscrypt-proxy.toml` configuration file:
 
     [sources.'onion-services']
-    urls = ['https://raw.githubusercontent.com/DNSCrypt/dnscrypt-resolvers/master/v3/onion-services.md', 'https://download.dnscrypt.info/resolvers-list/v3/onion-services.md', 'https://ipv6.download.dnscrypt.info/resolvers-list/v3/onion-services.md']
+    urls = ['https://raw.githubusercontent.com/DNSCrypt/dnscrypt-resolvers/master/v3/onion-services.md', 'https://download.dnscrypt.info/resolvers-list/v3/onion-services.md', 'https://cdn.jsdelivr.net/gh/DNSCrypt/dnscrypt-resolvers@master/v3/onion-services.md']
     minisign_key = 'RWQf6LRCGA9i53mlYecO4IzT51TGPpvWucNSCh1CBM0QTaLn73Y7GFO3'
     cache_file = 'onion-services.md'
 


### PR DESCRIPTION
Remove non-functional https://ipv6.download.dnscrypt.info source. Add new https://cdn.jsdelivr.net source.