### PR TITLE
Add sorcerousmachine resolver (OpenNIC Tier-2)

### DIFF
--- a/v3/opennic.subset
+++ b/v3/opennic.subset
@@ -30,3 +30,7 @@ opennameserver-4-doh
 opennic-R4SAS
 publicarray-au-doh
 publicarray-au2-doh
+sorcerousmachine
+sorcerousmachine-doh
+sorcerousmachine-doh-ipv6
+sorcerousmachine-ipv6

--- a/v3/public-resolvers.md
+++ b/v3/public-resolvers.md
@@ -5058,6 +5058,38 @@ Maintained by Frank Denis - https://fr.dnscrypt.info/sfw.html
 sdns://AQMAAAAAAAAADzE2My4xNzIuMTgwLjEyNSDfYnO_x1IZKotaObwMhaw_-WRF1zZE9mJygl01WPGh_x8yLmRuc2NyeXB0LWNlcnQuc2Z3LnNjYWxld2F5LWZy
 
 
+## sorcerousmachine
+
+Public, no-logs, non-filtering OpenNIC Tier-2 recursive resolver. DNSSEC against IANA and OpenNIC root anchors. Operated by Sorcerous Machine, LLC in Warrenton, VA, US.
+https://dns.sorcerousmachine.com/
+
+sdns://AQcAAAAAAAAAEjE1LjIwNC4xMzUuMjg6ODQ0MyBMpSYYYGo1AnEYIVggIK6tOA-aNBsMnVpbm8QvfUn23ygyLmRuc2NyeXB0LWNlcnQuZG5zLnNvcmNlcm91c21hY2hpbmUuY29t
+
+
+## sorcerousmachine-doh
+
+Public, no-logs, non-filtering OpenNIC Tier-2 recursive resolver (DoH). DNSSEC against IANA and OpenNIC root anchors. Operated by Sorcerous Machine, LLC in Warrenton, VA, US.
+https://dns.sorcerousmachine.com/
+
+sdns://AgcAAAAAAAAADTE1LjIwNC4xMzUuMjgAGGRucy5zb3JjZXJvdXNtYWNoaW5lLmNvbQovZG5zLXF1ZXJ5
+
+
+## sorcerousmachine-doh-ipv6
+
+Public, no-logs, non-filtering OpenNIC Tier-2 recursive resolver (DoH, IPv6). DNSSEC against IANA and OpenNIC root anchors. Operated by Sorcerous Machine, LLC in Warrenton, VA, US.
+https://dns.sorcerousmachine.com/
+
+sdns://AgcAAAAAAAAAFlsyNjA0OjJkYzA6MTAwOjRjODo6ZF0AGGRucy5zb3JjZXJvdXNtYWNoaW5lLmNvbQovZG5zLXF1ZXJ5
+
+
+## sorcerousmachine-ipv6
+
+Public, no-logs, non-filtering OpenNIC Tier-2 recursive resolver (IPv6). DNSSEC against IANA and OpenNIC root anchors. Operated by Sorcerous Machine, LLC in Warrenton, VA, US.
+https://dns.sorcerousmachine.com/
+
+sdns://AQcAAAAAAAAAG1syNjA0OjJkYzA6MTAwOjRjODo6ZF06ODQ0MyBMpSYYYGo1AnEYIVggIK6tOA-aNBsMnVpbm8QvfUn23ygyLmRuc2NyeXB0LWNlcnQuZG5zLnNvcmNlcm91c21hY2hpbmUuY29t
+
+
 ## switch
 
 Public DoH service provided by SWITCH in Switzerland. Provides protection against malware, but does not block ads.


### PR DESCRIPTION
Adds four entries (DNSCrypt v4/v6, DoH v4/v6) for a new public OpenNIC
Tier-2 resolver: dns.sorcerousmachine.com.

- Listed at servers.opennic.org as a public Tier-2.
- No-logs, non-filtering.
- DNSSEC validation against IANA + OpenNIC root anchors.
- Stamps validated locally with dnscrypt-proxy 2.x prior to submission.
- Names appended to v3/opennic.subset for inclusion in opennic.md.

Note on DoH cert hashes: intentionally omitted. The resolver uses
Let's Encrypt with automatic ~60-day renewal, so a pinned hash would
invalidate the registry entry on every renewal. Clients fall back to
system trust roots, same as a browser.