### PR TITLE
Enhance vpsdns-za-doh description with DNSSEC

### DIFF
--- a/v3/public-resolvers.md
+++ b/v3/public-resolvers.md
@@ -5007,9 +5007,9 @@ sdns://AQcAAAAAAAAAEjEwMi4yMTQuMTAuODI6ODQ0MyAp_ZK8Ab77yIXFI7AIeSrgjZjUJ2zG9acKC
 
 ## vpsdns-za-doh
 
-High-performance privacy DoH resolver based in South Africa. Zero logging, unfiltered raw resolution.
+High-performance privacy DoH resolver based in South Africa. Zero logging, DNSSEC validation, unfiltered raw resolution.
 
-sdns://AgYAAAAAAAAADTEwMi4yMTQuMTAuODIg5vEeyAbBx-ZMKDCsuvSaiZNVC7pEWvVl-yEncW8dIkgQZG9oLnZwc2Rucy5jby56YQovZG5zLXF1ZXJ5
+sdns://AgcAAAAAAAAAETEwMi4yMTQuMTAuODI6NDQzIObxHsgGwcfmTCgwrLr0momTVQu6RFr1ZfshJ3FvHSJIEGRvaC52cHNkbnMuY28uemEKL2Rucy1xdWVyeQ
 
 
 ## wikimedia


### PR DESCRIPTION
As per previous converstion regarding DNSSEC, https://github.com/dnscrypt/doh-server has been successfully deployed as the frontend proxy for the Technitium DNS backend. Upstream DNSSEC validation handling is fully functional, with the ad (Authentic Data) flag and RRSIG records preserving structural integrity over the WAN:

  dig @doh.vpsdns.co.za cloudflare.com +dnssec
;; Truncated, retrying in TCP mode.

; <<>> DiG 9.20.23 <<>> @doh.vpsdns.co.za cloudflare.com +dnssec ; (1 server found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 57725 ;; flags: qr rd ra ad; QUERY: 1, ANSWER: 3, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags: do; udp: 1232
;; QUESTION SECTION:
;cloudflare.com.                        IN      A

;; ANSWER SECTION:
cloudflare.com.         300     IN      A       104.16.133.229
cloudflare.com.         300     IN      A       104.16.132.229
cloudflare.com.         300     IN      RRSIG   A 13 2 300 20260525202120 20260523182120 34505 cloudflare.com. vCIel0zTYLISGNupGozHZIreuRD7SQN+b+6Bh5JyH9DEIrEC0yfCKALF vfY6yWKv0XWxxne5ke5bFSn8j4NDyw==

;; Query time: 30 msec
;; SERVER: 102.214.10.82#53(doh.vpsdns.co.za) (TCP)
;; WHEN: Sun May 24 21:21:36 SAST 2026
;; MSG SIZE  rcvd: 185