### PR TITLE
feat(olilo): add Olilo new DoH endpoints

### DIFF
--- a/v3/public-resolvers.md
+++ b/v3/public-resolvers.md
@@ -4880,6 +4880,26 @@ Operated by NWPS.fi. Service page: https://nwps.fi/wordpress/free-recursive-dns/
 sdns://AQcAAAAAAAAAETk1LjIxNy4xMS42Mzo4NDQzILqK827XPyVhFNCgYRi2VrryJyHhnfkeQnBB2EvkiM-3FzIuZG5zY3J5cHQtY2VydC5ud3BzLmZp
 
 
+## olilo-doh
+
+Olilo public resolver. Two nodes in London.
+No logging, no filtering, DNSSEC validation. No EDNS Client Subnet.
+Operated by Olilo (AS212683). DNS service: https://dns.as212683.net
+
+sdns://AgcAAAAAAAAADDUuMTgyLjExNS43NAAQZG5zLmFzMjEyNjgzLm5ldAovZG5zLXF1ZXJ5
+sdns://AgcAAAAAAAAADDUuMTgyLjExNS43NQAQZG5zLmFzMjEyNjgzLm5ldAovZG5zLXF1ZXJ5
+
+
+## olilo-doh-ipv6
+
+Olilo public resolver. Two nodes in London.
+IPv6 endpoint. No logging, no filtering, DNSSEC validation. No EDNS Client Subnet.
+Operated by Olilo (AS212683). DNS service: https://dns.as212683.net
+
+sdns://AgcAAAAAAAAAElsyYTExOjI2NDY6MToyOjo0XQAQZG5zLmFzMjEyNjgzLm5ldAovZG5zLXF1ZXJ5
+sdns://AgcAAAAAAAAAElsyYTExOjI2NDY6MToyOjo1XQAQZG5zLmFzMjEyNjgzLm5ldAovZG5zLXF1ZXJ5
+
+
 ## plan9dns-fl
 
 plan9-dns Miami resolver.


### PR DESCRIPTION
Add Olilo's new DNS Service: https://blog.olilo.co.uk/blog/we-built-a-public-dns-resolver-and-you-can-use-it-or-dont/

```
┌────────────────┬────────────────────────────────────┬───────────────────────────┐
│     Entry      │     Addresses                      │           Props           │
├────────────────┼────────────────────────────────────┼───────────────────────────┤
│ olilo-doh      │ 5.182.115.74, 5.182.115.75         │ DNSSEC, No-log, No-filter │
├────────────────┼────────────────────────────────────┼───────────────────────────┤
│ olilo-doh-ipv6 │ 2a11:2646:1:2::4, 2a11:2646:1:2::5 │ DNSSEC, No-log, No-filter │
└────────────────┴────────────────────────────────────┴───────────────────────────┘
```